### PR TITLE
making assertion.target optional

### DIFF
--- a/checkly/resource_check.go
+++ b/checkly/resource_check.go
@@ -309,7 +309,7 @@ func resourceCheck() *schema.Resource {
 									},
 									"target": {
 										Type:     schema.TypeString,
-										Required: true,
+										Optional: true,
 									},
 								},
 							},


### PR DESCRIPTION
## Affected Components
* [x] Resources
* [ ] Tests
* [ ] Docs
* [ ] Other

## Style
* [x] Terraform code is formatted with `terraform fmt`
* [x] Go code is formatted with `go fmt`

fixes #63 .. Unfortunately, we can't require target for some assertions based on comparison type, tf ValidateFunc works only on primitive types and it has no access to other schema fields -> 'comparison', the validation will happen on the backend.