### PR TITLE
Support high frequency API Checks (frequency_offset)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ crash.log
 terraform-provider-checkly
 tf.plan
 dist/*
+.DS_Store
+.terraform.lock.hcl

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,5 +1,7 @@
 default: testacc
 
+version="0.0.2"
+
 # Run acceptance tests
 .PHONY: testacc
 testacc:
@@ -10,29 +12,33 @@ setup:
 	go get github.com/terraform-providers/terraform-provider-template
 	go install github.com/hashicorp/terraform
 	go install github.com/terraform-providers/terraform-provider-template
-	#After running the above commands, both Terraform core and the template 
-	# provider will both be installed in the current GOPATH and $GOPATH/bin 
-	# will contain both terraform and terraform-provider-template executables. 
-	# This terraform executable will find and use the template provider plugin 
-	# alongside it in the bin directory in preference to downloading and 
+	#After running the above commands, both Terraform core and the template
+	# provider will both be installed in the current GOPATH and $GOPATH/bin
+	# will contain both terraform and terraform-provider-template executables.
+	# This terraform executable will find and use the template provider plugin
+	# alongside it in the bin directory in preference to downloading and
 	# installing an official release.
 
 replace-dep:
 	go mod edit -replace github.com/checkly/checkly-go-sdk=../checkly-go-sdk
 
 plan:
-	# for dev purposes only, build the provider and install 
-	# it as dev/checkly/check 0.0.1, 
+	# for dev purposes only, build the provider and install
+	# it as dev/checkly/check + version number,
 	go build -o terraform-provider-checkly
-	mkdir -p ~/.terraform.d/plugins/dev/checkly/checkly/0.0.1/darwin_amd64/
+	mkdir -p ~/.terraform.d/plugins/dev/checkly/checkly/${version}/darwin_amd64/
 	chmod +x terraform-provider-checkly
-	mv terraform-provider-checkly ~/.terraform.d/plugins/dev/checkly/checkly/0.0.1/darwin_amd64/terraform-provider-checkly_v0.0.1
-	TF_LOG=TRACE terraform init  
-	terraform plan 
+	mv terraform-provider-checkly ~/.terraform.d/plugins/dev/checkly/checkly/${version}/darwin_amd64/terraform-provider-checkly_v${version}
+	rm .terraform.lock.hcl
+	TF_LOG=TRACE terraform init -upgrade
+	terraform plan
 	terraform apply
 
 apply:
 	terraform apply
+
+destroy:
+	terraform destroy
 
 format-code:
 	go fmt ./checkly

--- a/checkly/resource_check.go
+++ b/checkly/resource_check.go
@@ -573,12 +573,12 @@ func checkFromResourceData(d *schema.ResourceData) (checkly.Check, error) {
 		check.FrequencyOffset = d.Get("frequency_offset").(int)
 
 		if check.Frequency == 0 && (check.FrequencyOffset != 10 && check.FrequencyOffset != 20 && check.FrequencyOffset != 30) {
-			return check, errors.New("When frequency == 0, frequency_offset must be 10, 20 or 30")
+			return check, errors.New("When property frequency is 0, frequency_offset must be 10, 20 or 30")
 		}
 	}
 
 	if check.Type == checkly.TypeBrowser && check.Frequency == 0 {
-		return check, errors.New("frequency == 0 is only valid for API checks")
+		return check, errors.New("Property frequency could only be 0 for API checks")
 	}
 
 	return check, nil

--- a/docs/resources/check.md
+++ b/docs/resources/check.md
@@ -1,6 +1,6 @@
 # checkly_check
-`checkly_check` allows users to manage checkly checks. Add a `checkly_check` resource to your resource file. 
- 
+`checkly_check` allows users to manage checkly checks. Add a `checkly_check` resource to your resource file.
+
 ## Example Usage - API checks
 This first example is a very minimal **API check**.
 
@@ -103,7 +103,7 @@ resource "checkly_check" "example-check-2" {
     }
   }
 }
-```  
+```
 
 
 ## Example Usage - Browser checks
@@ -154,7 +154,7 @@ resource "checkly_check" "browser-check-1" {
 
 ## Example Usage - With Alert channels
 first define an alert channel
-```terraform 
+```terraform
 resource "checkly_alert_channel" "email_ac1" {
   email {
     address = "info1@example.com"
@@ -204,34 +204,35 @@ resource "checkly_check" "example-check" {
 }
 ```
 
-## Argument Reference  
+## Argument Reference
 The following arguments are supported:
-* `name` - (Required) The name of the check.  
-* `type` - (Required) The type of the check. Possible values are `API`, and `BROWSER`.  
-* `frequency` (Required) The frequency in minutes to run the check. Possible values are `1`, `5`, `10`, `15`, `30`, `60`, `720`, and `1440`.
-* `activated` (Required) Determines if the check is running or not. Possible values `true`, and `false`.  
-* `muted` (Optional) Determines if any notifications will be sent out when a check fails and/or recovers. Possible values `true`, and `false`.  
-* `double_check` (Optional) Setting this to "true" will trigger a retry when a check fails from the failing region and another, randomly selected region before marking the check as failed. Possible values `true`, and `false`.  
-* `ssl_check` (Optional) Determines if the SSL certificate should be validated for expiry. Possible values `true`, and `false`.  
-* `should_fail` (Optional) Allows to invert the behaviour of when a check is considered to fail. Allows for validating error status like 404. Possible values `true`, and `false`.  
-* `locations` (Required) An array of one or more data center locations where to run the this check.  
-* `script` (Optional) A valid piece of Node.js javascript code describing a browser interaction with the Puppeteer framework or a terraform reference to an external javascript file.  
-* `environment_variables` (Optional) Key/value pairs for setting environment variables during check execution. These are only relevant for Browser checks. Use global environment variables whenever possible.  
-* `Tags` (Optional) A list of Tags for organizing and filtering checks. 
-* `setup_snippet_id` (Optional) An ID reference to a snippet to use in the setup phase of an API check.  
-* `teardown_snippet_id` (Optional) An ID reference to a snippet to use in the teardown phase of an API check.  
-* `local_setup_script` (Optional) A valid piece of Node.js code to run in the setup phase.  
+* `name` - (Required) The name of the check.
+* `type` - (Required) The type of the check. Possible values are `API`, and `BROWSER`.
+* `frequency` (Required) The frequency in minutes to run the check. Possible values are `0`, `1`, `5`, `10`, `15`, `30`, `60`, `720`, and `1440`.
+* `frequency_offset` (Optional) This property only valid for API high frequency checks. To create a hight frequency check, the property `frequency` must be `0` and `frequency_offset` could be `10`, `20` or `30`.
+* `activated` (Required) Determines if the check is running or not. Possible values `true`, and `false`.
+* `muted` (Optional) Determines if any notifications will be sent out when a check fails and/or recovers. Possible values `true`, and `false`.
+* `double_check` (Optional) Setting this to "true" will trigger a retry when a check fails from the failing region and another, randomly selected region before marking the check as failed. Possible values `true`, and `false`.
+* `ssl_check` (Optional) Determines if the SSL certificate should be validated for expiry. Possible values `true`, and `false`.
+* `should_fail` (Optional) Allows to invert the behaviour of when a check is considered to fail. Allows for validating error status like 404. Possible values `true`, and `false`.
+* `locations` (Required) An array of one or more data center locations where to run the this check.
+* `script` (Optional) A valid piece of Node.js javascript code describing a browser interaction with the Puppeteer framework or a terraform reference to an external javascript file.
+* `environment_variables` (Optional) Key/value pairs for setting environment variables during check execution. These are only relevant for Browser checks. Use global environment variables whenever possible.
+* `Tags` (Optional) A list of Tags for organizing and filtering checks.
+* `setup_snippet_id` (Optional) An ID reference to a snippet to use in the setup phase of an API check.
+* `teardown_snippet_id` (Optional) An ID reference to a snippet to use in the teardown phase of an API check.
+* `local_setup_script` (Optional) A valid piece of Node.js code to run in the setup phase.
 * `local_teardown_script` (Optional) A valid piece of Node.js code to run in the teardown phase.
-* `use_global_alert_settings` (Optional) When true, the account level alert setting will be used, not the alert setting defined on this check. Possible values `true`, and `false`.  
-* `degraded_response_time` (Optional) The response time in milliseconds where a check should be considered degraded. Possible values are between 0 and 30000. Defaults to `15000`.  
-* `max_response_time` (Optional) The response time in milliseconds where a check should be considered failing. Possible values are between 0 and 30000. Defaults to `30000`.  
+* `use_global_alert_settings` (Optional) When true, the account level alert setting will be used, not the alert setting defined on this check. Possible values `true`, and `false`.
+* `degraded_response_time` (Optional) The response time in milliseconds where a check should be considered degraded. Possible values are between 0 and 30000. Defaults to `15000`.
+* `max_response_time` (Optional) The response time in milliseconds where a check should be considered failing. Possible values are between 0 and 30000. Defaults to `30000`.
 * `group_id` (Optional). The id of the check group this check is part of.
-* `group_order` (Optional) The position of this check in a check group. It determines in what order checks are run when a group is triggered from the API or from CI/CD.  
-* `request` (Optional). An API check might have one request config. Supported values documented below.    
-* `alert_settings` (Optional). Supported values documented below.  
+* `group_order` (Optional) The position of this check in a check group. It determines in what order checks are run when a group is triggered from the API or from CI/CD.
+* `request` (Optional). An API check might have one request config. Supported values documented below.
+* `alert_settings` (Optional). Supported values documented below.
 
 ### Argument Reference: request
-The `request` section is added to API checks and supports the following:  
+The `request` section is added to API checks and supports the following:
 * `method` (Optional) The HTTP method to use for this API check. Possible values are `GET`, `POST`, `PUT`, `HEAD`, `DELETE`, `PATCH`. Defaults to `GET`.
 * `url` (Required) .
 * `follow_redirects` (Optional) .
@@ -239,26 +240,26 @@ The `request` section is added to API checks and supports the following:
 * `query_parameters` (Optional).
 * `body` (Optional)
 * `body_type` (Optional) Possible values `NONE`, `JSON`, `FORM`, `RAW`, and `GRAPHQL`.
-* `assertion` (Optional) A request can have multiple assetions. Assertion has the following arguments:  
-  * `source` (Required) Possible values `STATUS_CODE`, `JSON_BODY`, `HEADERS`, `TEXT_BODY`, and `RESPONSE_TIME`.  
-  * `property` (Optional).  
-  * `comparison` (Required) Possible values `EQUALS`, `NOT_EQUALS`, `HAS_KEY`, `NOT_HAS_KEY`, `HAS_VALUE`, `NOT_HAS_VALUE`, `IS_EMPTY`, `NOT_EMPTY`, `GREATER_THAN`, `LESS_THAN`, `CONTAINS`, `NOT_CONTAINS`, `IS_NULL`, and `NOT_NULL`.  
-  * `target` (Required).  
+* `assertion` (Optional) A request can have multiple assetions. Assertion has the following arguments:
+  * `source` (Required) Possible values `STATUS_CODE`, `JSON_BODY`, `HEADERS`, `TEXT_BODY`, and `RESPONSE_TIME`.
+  * `property` (Optional).
+  * `comparison` (Required) Possible values `EQUALS`, `NOT_EQUALS`, `HAS_KEY`, `NOT_HAS_KEY`, `HAS_VALUE`, `NOT_HAS_VALUE`, `IS_EMPTY`, `NOT_EMPTY`, `GREATER_THAN`, `LESS_THAN`, `CONTAINS`, `NOT_CONTAINS`, `IS_NULL`, and `NOT_NULL`.
+  * `target` (Required).
 * `basic_auth` (Optional) A request might have one basic_auth config. basic_auth has two arguments:
-  * `username` (Required)  
-  * `password` (Required)  
+  * `username` (Required)
+  * `password` (Required)
 
 
 ### Argument Reference: alert_settings
-The `alert_Settings` section supports the following:  
-* `escalation_type` (Optional) Determines what type of escalation to use. Possible values are `RUN_BASED` or `TIME_BASED`.  
+The `alert_Settings` section supports the following:
+* `escalation_type` (Optional) Determines what type of escalation to use. Possible values are `RUN_BASED` or `TIME_BASED`.
 * `run_based_escalation` (Optional). Possible arguments:
-  * `failed_run_threshold` (Optional) After how many failed consecutive check runs an alert notification should be send. Possible values are between 1 and 5. Defaults to `1`.  
+  * `failed_run_threshold` (Optional) After how many failed consecutive check runs an alert notification should be send. Possible values are between 1 and 5. Defaults to `1`.
 * `time_based_escalation` (Optional). Possible arguments:
-  * `minutes_failing_threshold` (Optional) After how many minutes after a check starts failing an alert should be send. Possible values are `5`, `10`, `15`, and `30`. Defaults to `5`.  
+  * `minutes_failing_threshold` (Optional) After how many minutes after a check starts failing an alert should be send. Possible values are `5`, `10`, `15`, and `30`. Defaults to `5`.
 * `reminders` (Optional). Possible arguments:
   * `amount` (Optional) How many reminders to send out after the initial alert notification. Possible values are `0`, `1`, `2`, `3`, `4`, `5`, and `100000`
-  * `interval` (Optional). Possible values are `5`, `10`, `15`, and `30`. Defaults to `5`.  
+  * `interval` (Optional). Possible values are `5`, `10`, `15`, and `30`. Defaults to `5`.
 * `ssl_certificates` (Optional) At what interval the reminders should be send.  Possible arguments:
-  * `enabled` (Optional) Determines if alert notifications should be send for expiring SSL certificates. Possible values `true`, and `false`. Defaults to `true`.  
-  * `alert_threshold` (Optional) At what moment in time to start alerting on SSL certificates. Possible values `3`, `7`, `14`, `30`. Defaults to `3`.  
+  * `enabled` (Optional) Determines if alert notifications should be send for expiring SSL certificates. Possible values `true`, and `false`. Defaults to `true`.
+  * `alert_threshold` (Optional) At what moment in time to start alerting on SSL certificates. Possible values `3`, `7`, `14`, `30`. Defaults to `3`.

--- a/go.mod
+++ b/go.mod
@@ -25,4 +25,4 @@ require (
 	golang.org/x/sys v0.0.0-20200602225109-6fdc65e7d980 // indirect
 )
 
-replace github.com/checkly/checkly-go-sdk => ../checkly-go-sdk
+// replace github.com/checkly/checkly-go-sdk => ../checkly-go-sdk

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.14
 require (
 	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/aws/aws-sdk-go v1.31.11 // indirect
-	github.com/checkly/checkly-go-sdk v1.0.1
+	github.com/checkly/checkly-go-sdk v1.1.0
 	github.com/fatih/color v1.9.0 // indirect
 	github.com/google/go-cmp v0.5.0
 	github.com/gruntwork-io/terratest v0.18.3

--- a/go.mod
+++ b/go.mod
@@ -25,4 +25,4 @@ require (
 	golang.org/x/sys v0.0.0-20200602225109-6fdc65e7d980 // indirect
 )
 
-//replace github.com/checkly/checkly-go-sdk => ../checkly-go-sdk
+replace github.com/checkly/checkly-go-sdk => ../checkly-go-sdk

--- a/install-0.12.sh
+++ b/install-0.12.sh
@@ -17,12 +17,12 @@ jq_cmd=".assets[] | select(.name | endswith(\"${platform}.gz\")).browser_downloa
 # Find latest binary release URL for this platform
 url="$(curl -s https://api.github.com/repos/checkly/terraform-provider-checkly/releases/latest | jq -r "${jq_cmd}")"
 # Download the tarball
-curl -OL ${url}
+curl -OL "${url}"
 # Rename and copy to your Terraform plugin folder
-filename=$(basename $url)
-gunzip ${filename}
-filename=${filename%.gz}
-chmod +x ${filename}
+filename=$(basename "$url")
+gunzip "${filename}"
+filename="${filename%.gz}"
+chmod +x "${filename}"
 PLUGIN_DIR=~/.terraform.d/plugins/$platform
 mkdir -p $PLUGIN_DIR
-mv $filename ${PLUGIN_DIR}/${filename%_${platform}}
+mv "$filename" "${PLUGIN_DIR}"/"${filename%_${platform}}"

--- a/install-0.13.sh
+++ b/install-0.13.sh
@@ -20,12 +20,12 @@ url="$(curl -s https://api.github.com/repos/checkly/terraform-provider-checkly/r
 # Get the version of the latest binary release (e.g. 0.6.6)
 ver="$(curl -s https://api.github.com/repos/checkly/terraform-provider-checkly/releases/latest | jq -r "${jq_ver_cmd}")"
 # Download the tarball
-curl -OL ${url}
+curl -OL "${url}"
 # Rename and copy to your Terraform plugin folder
-filename=$(basename $url)
-gunzip ${filename}
+filename=$(basename "$url")
+gunzip "${filename}"
 filename=${filename%.gz}
-chmod +x ${filename}
+chmod +x "${filename}"
 PLUGIN_DIR=~/.terraform.d/plugins/local/checkly/checkly/$ver/$platform
-mkdir -p $PLUGIN_DIR
-mv $filename ${PLUGIN_DIR}/${filename%_${platform}}
+mkdir -p "$PLUGIN_DIR"
+mv "$filename" "${PLUGIN_DIR}"/"${filename%_${platform}}"

--- a/test.tf
+++ b/test.tf
@@ -8,8 +8,7 @@
 resource "checkly_check" "api-check-1" {
   name              = "API check 1"
   type              = "API"
-  frequency         = 10
-  frequency_offset  = 20
+  frequency         = 60
   activated         = true
   muted             = true
   double_check      = true

--- a/test.tf
+++ b/test.tf
@@ -1,6 +1,6 @@
 #-- This file provides example terraform resource definitions that create checkly resources
 
-################################# API CHECKS ################################# 
+################################# API CHECKS #################################
 
 #----------------------------EXAMPLE----------------------------#
 #-- a very simple API check definition
@@ -8,7 +8,8 @@
 resource "checkly_check" "api-check-1" {
   name              = "API check 1"
   type              = "API"
-  frequency         = 60
+  frequency         = 10
+  frequency_offset  = 20
   activated         = true
   muted             = true
   double_check      = true
@@ -216,7 +217,7 @@ resource "checkly_check" "api-check-4" {
 }
 
 
-################################# BROWSER CHECKS ################################# 
+################################# BROWSER CHECKS #################################
 
 #----------------------------EXAMPLE----------------------------#
 #-- a Browser Check which runs E2E test
@@ -226,7 +227,7 @@ resource "checkly_check" "browser-check-2" {
   type                      = "BROWSER"
   activated                 = true
   should_fail               = false
-  frequency                 = 10
+  frequency                 = 15
   double_check              = true
   ssl_check                 = true
   use_global_alert_settings = true
@@ -266,9 +267,9 @@ EOT
 }
 
 
-################################# CHECK GROUPS ################################# 
-## Checkly's groups feature allows you to group together a set of related checks, 
-## which can also share default settings for various attributes. Here is an 
+################################# CHECK GROUPS #################################
+## Checkly's groups feature allows you to group together a set of related checks,
+## which can also share default settings for various attributes. Here is an
 ## example check group:
 
 #----------------------------EXAMPLE----------------------------#
@@ -374,7 +375,7 @@ resource "checkly_check_group" "check-group-3" {
 
 
 #----------------------------EXAMPLE----------------------------#
-#--- Adding a check to a check group 
+#--- Adding a check to a check group
 
 resource "checkly_check" "api-check-group-1_1" {
   name      = "API check 1 belonging to group 1"
@@ -417,7 +418,7 @@ resource "checkly_check" "api-check-group-1_2" {
   group_order = 2
 }
 
-################################# ALERT CHANNELS ################################# 
+################################# ALERT CHANNELS #################################
 
 resource "checkly_alert_channel" "email_ac" {
   email {

--- a/versions.tf
+++ b/versions.tf
@@ -2,11 +2,11 @@ terraform {
   required_version = ">= 0.13"
   required_providers {
     checkly = {
-      # dev/checkly/checkly is used for development only, 
-      # if you're using checkly provider you'll need to follow 
+      # dev/checkly/checkly is used for development only,
+      # if you're using checkly provider you'll need to follow
       # installation guide instrctions found in README
       source  = "dev/checkly/checkly"
-      version = "0.0.1"
+      version = "0.0.2"
     }
   }
 }


### PR DESCRIPTION
## Affected Components
* [x] Resources
* [ ] Tests
* [x] Docs
* [ ] Other

## Style
* [x] Terraform code is formatted with `terraform fmt`
* [x] Go code is formatted with `go fmt`

## Notes for the Reviewer
Add support for high-frequency checks using `frequency_offset`.
Is not 100% but would like to open it as a draft to start reviewing it and validate functionality.

- `frequency_offset` will only be valid for API Checks and when the value of `frequency` equals 0.
- `frequency_offset` is ignored in other scenarios than above.
- `frequency_offset` should not break existing checks and will not present TF changes unless you set the `frequency` to 0 (in a API Check)

> Resolves https://github.com/checkly/terraform-provider-checkly/issues/68
**Depends on https://github.com/checkly/checkly-go-sdk/pull/27**