### PR TITLE
feat: suport versioned runtime in checks/groups (runtime_id)

### DIFF
--- a/docs/resources/alert-channel.md
+++ b/docs/resources/alert-channel.md
@@ -1,5 +1,5 @@
 # checkly_alert_channel
-The `checkly_alert_channel` resource allows users to manage checkly Alert Channels.
+The `checkly_alert_channel` resource allows users to manage Checkly alert channels.
 
 Checkly's Alert Channels feature allows you to define global alerting channels for the checks in your account:
 

--- a/docs/resources/check.md
+++ b/docs/resources/check.md
@@ -1,5 +1,5 @@
 # checkly_check
-`checkly_check` allows users to manage checkly checks. Add a `checkly_check` resource to your resource file.
+`checkly_check` allows users to manage Checkly checks. Add a `checkly_check` resource to your resource file.
 
 ## Example Usage - API checks
 This first example is a very minimal **API check**.
@@ -123,6 +123,8 @@ resource "checkly_check" "browser-check-1" {
     "us-west-1"
   ]
 
+  runtime_id = "2021.06"
+
   script = <<EOT
 const assert = require("chai").assert;
 const puppeteer = require("puppeteer");
@@ -230,6 +232,7 @@ The following arguments are supported:
 * `group_order` (Optional) The position of this check in a check group. It determines in what order checks are run when a group is triggered from the API or from CI/CD.
 * `request` (Optional). An API check might have one request config. Supported values documented below.
 * `alert_settings` (Optional). Supported values documented below.
+* `runtime_id` (Optional). The id of the runtime to use for this check.
 
 ### Argument Reference: request
 The `request` section is added to API checks and supports the following:

--- a/docs/resources/check_group.md
+++ b/docs/resources/check_group.md
@@ -1,5 +1,5 @@
 # checkly_check_group
-The `checkly_check_group` resource allows users to manage checkly Check Groups.
+The `checkly_check_group` resource allows users to manage Checkly check groups.
 
 Checkly's groups feature allows you to group together a set of related checks, which can also share default settings for various attributes. Here is an example check group:
 
@@ -154,6 +154,7 @@ resource "checkly_check_group" "test-group1" {
 * `use_global_alert_settings` (Optional) When true, the account level alert setting will be used, not the alert setting defined on this check group.
 * `api_check_defaults` (Optional) Default configs to use for all api checks belonging to this group. Supported values documented below.
 * `alert_settings` (Optional). Supported values documented below.
+* `runtime_id` (Optional). The id of the runtime to use for this group.
 
 
 ### Argument Reference: api_check_defaults

--- a/docs/resources/snippet.md
+++ b/docs/resources/snippet.md
@@ -1,6 +1,6 @@
 # checkly_snippet
-`checkly_snippet` allows users to manage checkly snippets. Add a `checkly_snippet` resource to your resource file. 
- 
+`checkly_snippet` allows users to manage Checkly snippets. Add a `checkly_snippet` resource to your resource file.
+
 ## Example Usage
 
 ```terraform
@@ -35,7 +35,7 @@ resource "checkly_snippet" "example-3" {
 }
 ```
 
-## Argument Reference  
+## Argument Reference
 The following arguments are supported:
-* `name` - (Required) The name of the snippet.  
+* `name` - (Required) The name of the snippet.
 * `script` - (Required) Your Node.js code that interacts with the API check lifecycle, or functions as a partial for browser checks.

--- a/go.mod
+++ b/go.mod
@@ -24,5 +24,3 @@ require (
 	github.com/zclconf/go-cty v1.4.2 // indirect
 	golang.org/x/sys v0.0.0-20200602225109-6fdc65e7d980 // indirect
 )
-
-// replace github.com/checkly/checkly-go-sdk => ../checkly-go-sdk

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.14
 require (
 	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/aws/aws-sdk-go v1.31.11 // indirect
-	github.com/checkly/checkly-go-sdk v1.2.0
+	github.com/checkly/checkly-go-sdk v1.3.0
 	github.com/fatih/color v1.9.0 // indirect
 	github.com/google/go-cmp v0.5.0
 	github.com/gruntwork-io/terratest v0.18.3

--- a/go.sum
+++ b/go.sum
@@ -58,6 +58,8 @@ github.com/checkly/checkly-go-sdk v1.0.1 h1:VXq27maQzihS3ZdbgaNGSJckI2BvlUxUg4qu
 github.com/checkly/checkly-go-sdk v1.0.1/go.mod h1:wkAoXD2cVCNQEXi9lHZqy/zONIAZc5D9frih6Gas3Rs=
 github.com/checkly/checkly-go-sdk v1.1.0 h1:a28JXarOuR6wQ8OO9I3p6puAnIvxjM+2XKsZL+7Mn74=
 github.com/checkly/checkly-go-sdk v1.1.0/go.mod h1:wkAoXD2cVCNQEXi9lHZqy/zONIAZc5D9frih6Gas3Rs=
+github.com/checkly/checkly-go-sdk v1.3.0 h1:eDaohYTyrjkPEWRmf3vDmzYseRE5Vek2i2r5yBzup7w=
+github.com/checkly/checkly-go-sdk v1.3.0/go.mod h1:wkAoXD2cVCNQEXi9lHZqy/zONIAZc5D9frih6Gas3Rs=
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=

--- a/test.tf
+++ b/test.tf
@@ -251,6 +251,8 @@ resource "checkly_check" "browser-check-1" {
     "us-west-1"
   ]
 
+  runtime_id = "2020.01"
+
   script = <<EOT
 const assert = require("chai").assert;
 const puppeteer = require("puppeteer");


### PR DESCRIPTION
## Affected Components
* [x] Resources
* [ ] Tests
* [x] Docs
* [ ] Other

## Style
* [x] Terraform code is formatted with `terraform fmt`
* [x] Go code is formatted with `go fmt`


## Notes for the Reviewer
- Add support for versioned runtimes

> Resolves #75 
> Depends on https://github.com/checkly/checkly-go-sdk/pull/33