### PR TITLE
docs: update provider version

### DIFF
--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -1,15 +1,12 @@
 # Installing the provider and getting started
 
-1. Make sure terraform 0.13 is installed on your system
-
-2. Create a `versions.tf` terraform config file in your project:
+1. Create a `versions.tf` terraform config file in your project:
 ```terraform
 terraform {
-  required_version = ">= 0.13"
   required_providers {
     checkly = {
       source = "checkly/checkly"
-      version = "0.7.1"
+      version = "1.2.0"
     }
   }
 }
@@ -22,9 +19,9 @@ provider "checkly" {
 }
 ```
 
-3. To use the provider with your Checkly account, you will need an API Key for the account. Go to the [Account Settings: API Keys page](https://app.checklyhq.com/account/api-keys) and click 'Create API Key'. Get your api key and add it to your env `export TF_VAR_checkly_api_key=XXXXXX`
+2. To use the provider with your Checkly account, you will need an API Key for the account. Go to the [Account Settings: API Keys page](https://app.checklyhq.com/account/api-keys) and click 'Create API Key'. Get your api key and add it to your env `export TF_VAR_checkly_api_key=XXXXXX`
 
-4. Run `terraform providers`. The Checkly plugin should be listed.
+3. Run `terraform providers`. The Checkly plugin should be listed.
 
 ```bash
 terraform providers
@@ -32,7 +29,7 @@ terraform providers
 └── provider[registry.terraform.io/checkly/checkly] ***
 ```
 
-5. Create a tf resource config file, for example `example.tf`:
+4. Create a tf resource config file, for example `example.tf`:
 ```terraform
 resource "checkly_check_group" "first-group" {
   name        = "Group 1"
@@ -43,4 +40,4 @@ resource "checkly_check_group" "first-group" {
 }
 ```
 
-6. Now run `terraform init` and then `terraform plan` followed by `terraform apply`
+5. Now run `terraform init` and then `terraform plan` followed by `terraform apply`

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,7 +21,7 @@ terraform {
   required_providers {
     checkly = {
       source = "checkly/checkly"
-      version = "0.7.1"
+      version = "1.2.0"
     }
   }
 }


### PR DESCRIPTION
## Affected Components
* [ ] Resources
* [ ] Tests
* [x] Docs
* [ ] Other

## Notes for the Reviewer
@ianaya89 should we get rid of https://registry.terraform.io/providers/checkly/checkly/latest/docs/guides/support-for-terraform-0.12 ?