### PR TITLE
chore: update links to api keys page [4933]

### DIFF
--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -19,7 +19,7 @@ provider "checkly" {
 }
 ```
 
-2. To use the provider with your Checkly account, you will need an API Key for the account. Go to the [Account Settings: API Keys page](https://app.checklyhq.com/account/api-keys) and click 'Create API Key'. Get your api key and add it to your env `export TF_VAR_checkly_api_key=XXXXXX`
+2. To use the provider with your Checkly account, you will need an API Key for your Checkly user. Go to the [User Settings: API Keys page](https://app.checklyhq.com/settings/user/api-keys) and click 'Create API Key'. Get your api key and add it to your env `export TF_VAR_checkly_api_key=XXXXXX`
 
 3. Run `terraform providers`. The Checkly plugin should be listed.
 

--- a/docs/guides/support-for-terraform-0.12.md
+++ b/docs/guides/support-for-terraform-0.12.md
@@ -22,7 +22,7 @@ If you're having issues, please check [the Hashicorp docs on installing third pa
 
 ### Authentication
 
-To use the provider with your Checkly account, you will need an API Key for the account. Go to the [Account Settings: API Keys page](https://app.checklyhq.com/account/api-keys) and click 'Create API Key'.
+To use the provider with your Checkly account, you will need an API Key for your Checkly user. Go to the [User Settings: API Keys page](https://app.checklyhq.com/settings/user/api-keys) and click 'Create API Key'.
 
 Now expose the API key as an environment variable in your shell:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ This Terraform provider enables users to manage [Checkly](https://checklyhq.com)
 You can find a quick [step-by-step guide](https://www.checklyhq.com/docs/integrations/terraform/) in Checkly's documentation.
 
 ## Authentication
-To use the provider with your Checkly account, you will need an API Key for the account. Go to the [Account Settings: API Keys](https://app.checklyhq.com/account/api-keys) page to create a new API key or to use an existing one.
+To use the provider with your Checkly account, you will need an API Key for your Checkly user. Go to the [User Settings: API Keys page](https://app.checklyhq.com/settings/user/api-keys) page to create a new API key or to use an existing one.
 
 Now expose the API key as an environment variable in your shell:
 


### PR DESCRIPTION
## Affected Components
* [ ] Resources
* [ ] Tests
* [X] Docs
* [ ] Other

## Style
* [ ] Terraform code is formatted with `terraform fmt`
* [ ] Go code is formatted with `go fmt`

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->
This PR updates the links to the Api Keys page in the app.checklyhq.com, which moved from `app.checklyhq.com/account/api-keys` to `app.checklyhq.com/settings/user/api-keys`. 
I made a small tweak in the copy to reflect the fact that API keys are now user-based and not account-based anymore. 