### PR TITLE
feat: add url property and clean up trigger resources

### DIFF
--- a/checkly/resource_trigger_group.go
+++ b/checkly/resource_trigger_group.go
@@ -28,38 +28,42 @@ func resourceTriggerGroup() *schema.Resource {
 			"token": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
+			},
+			"url": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
 			},
 		},
 	}
 }
 
-func triggerGroupFromResourceData(d *schema.ResourceData) (checkly.TriggerGroup, error) {
-	ID, err := strconv.ParseInt(d.Id(), 10, 64)
+func triggerGroupFromResourceData(data *schema.ResourceData) (checkly.TriggerGroup, error) {
+	ID, err := strconv.ParseInt(data.Id(), 10, 64)
 	if err != nil {
-		if d.Id() != "" {
+		if data.Id() != "" {
 			return checkly.TriggerGroup{}, err
 		}
 		ID = 0
 	}
-	a := checkly.TriggerGroup{
+
+	return checkly.TriggerGroup{
 		ID:      ID,
-		GroupId: int64(d.Get("group_id").(int)),
-		Token:   d.Get("token").(string),
-	}
-
-	fmt.Printf("%v", a)
-
-	return a, nil
+		GroupId: int64(data.Get("group_id").(int)),
+		Token:   data.Get("token").(string),
+	}, nil
 }
 
-func resourceDataFromTriggerGroup(s *checkly.TriggerGroup, d *schema.ResourceData) error {
-	d.Set("group_id", s.GroupId)
-	d.Set("token", s.Token)
+func resourceDataFromTriggerGroup(trigger *checkly.TriggerGroup, data *schema.ResourceData) error {
+	data.Set("group_id", trigger.GroupId)
+	data.Set("token", trigger.Token)
+	data.Set("url", trigger.URL)
 	return nil
 }
 
-func resourceTriggerGroupCreate(d *schema.ResourceData, client interface{}) error {
-	tc, err := triggerGroupFromResourceData(d)
+func resourceTriggerGroupCreate(data *schema.ResourceData, client interface{}) error {
+	tc, err := triggerGroupFromResourceData(data)
 	if err != nil {
 		return fmt.Errorf("resourceTriggerGroupCreate: translation error: %w", err)
 	}
@@ -71,58 +75,46 @@ func resourceTriggerGroupCreate(d *schema.ResourceData, client interface{}) erro
 		return fmt.Errorf("CreateTriggerGroup: API error: %w", err)
 	}
 
-	d.SetId(fmt.Sprintf("%d", result.ID))
-	d.Set("token", result.Token)
+	data.SetId(fmt.Sprintf("%d", result.ID))
 
-	return resourceTriggerGroupRead(d, client)
+	return resourceTriggerGroupRead(data, client)
 }
 
-func resourceTriggerGroupDelete(d *schema.ResourceData, client interface{}) error {
-	tc, err := triggerGroupFromResourceData(d)
+func resourceTriggerGroupDelete(data *schema.ResourceData, client interface{}) error {
+	tc, err := triggerGroupFromResourceData(data)
 	if err != nil {
-		return fmt.Errorf("resourceTriggerGroupCreate: translation error: %w", err)
+		return fmt.Errorf("resourceTriggerGroupDelete: translation error: %w", err)
 	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), apiCallTimeout())
 	defer cancel()
 	err = client.(checkly.Client).DeleteTriggerGroup(ctx, tc.GroupId)
 	if err != nil {
-		return fmt.Errorf("resourceTriggerGroupDelete: API error: %w", err)
+		return fmt.Errorf("DeleteTriggerGroup: API error: %w", err)
 	}
+
 	return nil
 }
 
-func resourceTriggerGroupRead(d *schema.ResourceData, client interface{}) error {
-	tc, err := triggerGroupFromResourceData(d)
+func resourceTriggerGroupRead(data *schema.ResourceData, client interface{}) error {
+	trigger, err := triggerGroupFromResourceData(data)
 	if err != nil {
-		return fmt.Errorf("resourceTriggerCheckDelete: ID %s is not numeric: %w", d.Id(), err)
+		return fmt.Errorf("resourceTriggerGroupRead: ID %s is not numeric: %w", data.Id(), err)
 	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), apiCallTimeout())
-	mw, err := client.(checkly.Client).GetTriggerGroup(ctx, tc.GroupId)
+	result, err := client.(checkly.Client).GetTriggerGroup(ctx, trigger.GroupId)
 	defer cancel()
 	if err != nil {
 		if strings.Contains(err.Error(), "404") {
-			d.SetId("")
+			data.SetId("")
 			return nil
 		}
-		return fmt.Errorf("resourceTriggerGroupRead: API error: %w", err)
+		return fmt.Errorf("GetTriggerGroup: API error: %w", err)
 	}
-	return resourceDataFromTriggerGroup(mw, d)
+	return resourceDataFromTriggerGroup(result, data)
 }
 
-func resourceTriggerGroupUpdate(d *schema.ResourceData, client interface{}) error {
-	tc, err := triggerGroupFromResourceData(d)
-	if err != nil {
-		return fmt.Errorf("resourceTriggerGroupRead: translation error: %w", err)
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), apiCallTimeout())
-	result, err := client.(checkly.Client).GetTriggerGroup(ctx, tc.GroupId)
-	defer cancel()
-
-	if err != nil {
-		return fmt.Errorf("resourceTriggerGroupUpdate: API error: %w", err)
-	}
-
-	d.Set("token", result.Token)
-
-	return resourceTriggerCheckRead(d, client)
+func resourceTriggerGroupUpdate(data *schema.ResourceData, client interface{}) error {
+	return resourceTriggerCheckRead(data, client)
 }

--- a/docs/resources/trigger_check.md
+++ b/docs/resources/trigger_check.md
@@ -7,7 +7,11 @@ Trigger check example
 
 ```terraform
 resource "checkly_trigger_check" "test-trigger-check" {
-   check_id      = "215"
+   check_id = "c1ff95c5-d7f6-4a90-9ce2-1e605f117592"
+}
+
+output "test-trigger-check-url" {
+  value = checkly_trigger_check.test-trigger-check.url
 }
 ```
 

--- a/docs/resources/trigger_group.md
+++ b/docs/resources/trigger_group.md
@@ -7,7 +7,11 @@ Trigger group example
 
 ```terraform
 resource "checkly_trigger_group" "test-trigger-group" {
-   group_id      = "215"
+   group_id = "215"
+}
+
+output "test-trigger-group-url" {
+  value = checkly_trigger_group.test-trigger-group.url
 }
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.14
 require (
 	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/aws/aws-sdk-go v1.31.11 // indirect
-	github.com/checkly/checkly-go-sdk v1.5.1
+	github.com/checkly/checkly-go-sdk v1.5.2
 	github.com/fatih/color v1.9.0 // indirect
 	github.com/google/go-cmp v0.5.0
 	github.com/gruntwork-io/terratest v0.18.3

--- a/go.sum
+++ b/go.sum
@@ -56,6 +56,8 @@ github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d/go.mod h1:6QX/PXZ
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/checkly/checkly-go-sdk v1.5.1 h1:yL4Ecg3/YjwpiMgYlDwt/b7fV4Wq60EzlAFdv6usAIs=
 github.com/checkly/checkly-go-sdk v1.5.1/go.mod h1:wkAoXD2cVCNQEXi9lHZqy/zONIAZc5D9frih6Gas3Rs=
+github.com/checkly/checkly-go-sdk v1.5.2 h1:gmD1yNL3oU94FJt/BobCDCY3lKidBghPrfBXo4/X3HA=
+github.com/checkly/checkly-go-sdk v1.5.2/go.mod h1:wkAoXD2cVCNQEXi9lHZqy/zONIAZc5D9frih6Gas3Rs=
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=

--- a/test.tf
+++ b/test.tf
@@ -34,6 +34,14 @@ resource "checkly_check" "api-check-1" {
 
 }
 
+resource "checkly_trigger_check" "trigger-api-check-1" {
+  check_id = checkly_check.api-check-1.id
+}
+
+output "trigger_api_check-1-url" {
+  value = checkly_trigger_check.trigger-api-check-1.url
+}
+
 #----------------------------EXAMPLE----------------------------#
 #-- a fully fledged API check
 
@@ -283,6 +291,14 @@ resource "checkly_check_group" "check-group-1" {
     "eu-west-1",
     "eu-west-2",
   ]
+}
+
+resource "checkly_trigger_group" "trigger-check-group-1" {
+ group_id = checkly_check_group.check-group-1.id
+}
+
+output "trigger_check-group-1-url" {
+  value = checkly_trigger_group.trigger-check-group-1.url
 }
 
 #----------------------------EXAMPLE----------------------------#


### PR DESCRIPTION
## Affected Components
* [x] Resources
* [ ] Tests
* [ ] Docs
* [ ] Other

## Style
* [x] Terraform code is formatted with `terraform fmt`
* [x] Go code is formatted with `go fmt`


## Notes for the Reviewer

- Clean up check/group triggers resources
- Add `URL` property to triggers

> Depends on https://github.com/checkly/checkly-go-sdk/pull/63