### PR TITLE
feat: add 'jq' check

### DIFF
--- a/install-0.13.sh
+++ b/install-0.13.sh
@@ -2,14 +2,19 @@
 set -x
 
 # Determine architecture
-if [[ $(uname -s) == Darwin ]]
-then
+if [[ $(uname -s) == Darwin ]]; then
 	platform='darwin_amd64'
-elif [[ $(uname -s) == Linux ]]
-then
+elif [[ $(uname -s) == Linux ]]; then
 	platform='linux_amd64'
 else
 	echo "No supported architecture found, you need to install checkly terraform provider manually"
+	exit 1
+fi
+
+if [ ! "$(command -v jq)" ]; then
+	echo "Please install 'jq' to continue."
+	echo "On MacOS: brew install jq"
+	echo "On (Ubuntu) Linux: sudo apt install jq"
 	exit 1
 fi
 


### PR DESCRIPTION
## Affected Components
* [ ] Resources
* [ ] Tests
* [ ] Docs
* [x] Other

## Style
* [ ] Terraform code is formatted with `terraform fmt`
* [ ] Go code is formatted with `go fmt`

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

Small install script error check to check for the presence of `jq` before continuing.

**EDIT**:

Idk if its helpful, but figured I'd mention it, you can link with a Github shortcut URL directly to the latest release, like:

```
https://github.com/checkly/terraform-provider-checkly/releases/latest/download/asset-name.zip
```

Maybe you can just interoplate the users architecture into that string in place of `asset-name.zip` (like `https://github.com/checkly/terraform-provider-checkly/releases/latest/download/terraform-provider-checkly_latest_$platform.zip`) and skip a step from checking the API? 


See bottom of: https://docs.github.com/en/repositories/releasing-projects-on-github/linking-to-releases

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
