### PR TITLE
Antoinecoutellier/sc 6270/add skip ssl validation to api checks

### DIFF
--- a/checkly/resource_check.go
+++ b/checkly/resource_check.go
@@ -275,6 +275,10 @@ func resourceCheck() *schema.Resource {
 							Type:     schema.TypeBool,
 							Optional: true,
 						},
+						"skip_ssl": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
 						"headers": {
 							Type:     schema.TypeMap,
 							Optional: true,
@@ -509,6 +513,7 @@ func setFromRequest(r checkly.Request) []tfMap {
 	s["method"] = r.Method
 	s["url"] = r.URL
 	s["follow_redirects"] = r.FollowRedirects
+	s["skip_ssl"] = r.SkipSSL
 	s["body"] = r.Body
 	s["body_type"] = r.BodyType
 	s["headers"] = mapFromKeyValues(r.Headers)
@@ -722,6 +727,7 @@ func requestFromSet(s *schema.Set) checkly.Request {
 		Method:          res["method"].(string),
 		URL:             res["url"].(string),
 		FollowRedirects: res["follow_redirects"].(bool),
+		SkipSSL:         res["skip_ssl"].(bool),
 		Body:            res["body"].(string),
 		BodyType:        res["body_type"].(string),
 		Headers:         keyValuesFromMap(res["headers"].(tfMap)),

--- a/docs/guides/resource-examples.md
+++ b/docs/guides/resource-examples.md
@@ -65,6 +65,7 @@ resource "checkly_check" "api-check-2" {
     method           = "GET"
     url              = "https://api.checklyhq.com/public-stats"
     follow_redirects = true
+    skip_ssl         = false
 
     headers = {
       X-CUSTOM-1 = 1
@@ -149,6 +150,7 @@ resource "checkly_check" "api-check-3" {
     method           = "POST"
     url              = "https://jsonplaceholder.typicode.com/posts"
     follow_redirects = true
+    skip_ssl         = false
 
     headers = {
       Content-type = "application/json; charset=UTF-8"
@@ -207,6 +209,7 @@ resource "checkly_check" "api-check-4" {
 
   request {
     follow_redirects = false
+    skip_ssl         = false
     url              = "https://api.checklyhq.com/public-stats"
 
     basic_auth {
@@ -399,6 +402,7 @@ resource "checkly_check" "api-check-group-1_1" {
     method           = "GET"
     url              = "https://api.checklyhq.com/public-stats"
     follow_redirects = true
+    skip_ssl         = false
   }
 
   group_id    = checkly_check_group.check-group-1.id
@@ -420,6 +424,7 @@ resource "checkly_check" "api-check-group-1_2" {
     method           = "GET"
     url              = "https://api.checklyhq.com/public-stats"
     follow_redirects = true
+    skip_ssl         = false
   }
 
   group_id    = checkly_check_group.check-group-1.id

--- a/docs/resources/check.md
+++ b/docs/resources/check.md
@@ -22,6 +22,7 @@ resource "checkly_check" "example-check" {
   request {
     url              = "https://api.example.com/"
     follow_redirects = true
+    skip_ssl         = false
     assertion {
       source     = "STATUS_CODE"
       comparison = "EQUALS"
@@ -73,6 +74,7 @@ resource "checkly_check" "example-check-2" {
 
   request {
     follow_redirects = true
+    skip_ssl         = false
     url              = "http://api.example.com/"
 
     query_parameters = {
@@ -239,6 +241,7 @@ The `request` section is added to API checks and supports the following:
 * `method` (Optional) The HTTP method to use for this API check. Possible values are `GET`, `POST`, `PUT`, `HEAD`, `DELETE`, `PATCH`. Defaults to `GET`.
 * `url` (Required) .
 * `follow_redirects` (Optional) .
+* `skip_ssl` (Optional) .
 * `headers` (Optional) .
 * `query_parameters` (Optional).
 * `body` (Optional)

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.14
 require (
 	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/aws/aws-sdk-go v1.31.11 // indirect
-	github.com/checkly/checkly-go-sdk v1.5.5
+	github.com/checkly/checkly-go-sdk v1.5.6
 	github.com/fatih/color v1.9.0 // indirect
 	github.com/google/go-cmp v0.5.0
 	github.com/gruntwork-io/terratest v0.18.3

--- a/go.sum
+++ b/go.sum
@@ -64,6 +64,8 @@ github.com/checkly/checkly-go-sdk v1.5.4 h1:qwGxHgIPrTaXYrQAc/xkRzSvJtDEdN962n38
 github.com/checkly/checkly-go-sdk v1.5.4/go.mod h1:wkAoXD2cVCNQEXi9lHZqy/zONIAZc5D9frih6Gas3Rs=
 github.com/checkly/checkly-go-sdk v1.5.5 h1:uk6Djq/TkvLlaMOnEmaFVGlO5gZ2zLSq/dwChSpG/BQ=
 github.com/checkly/checkly-go-sdk v1.5.5/go.mod h1:wkAoXD2cVCNQEXi9lHZqy/zONIAZc5D9frih6Gas3Rs=
+github.com/checkly/checkly-go-sdk v1.5.6 h1:/P+7R0rxsC3g6eEQYLft4EM0ftI8KK55FUIotjvtfK0=
+github.com/checkly/checkly-go-sdk v1.5.6/go.mod h1:wkAoXD2cVCNQEXi9lHZqy/zONIAZc5D9frih6Gas3Rs=
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=

--- a/test.tf
+++ b/test.tf
@@ -297,7 +297,7 @@ resource "checkly_check_group" "check-group-1" {
 }
 
 resource "checkly_trigger_group" "trigger-check-group-1" {
- group_id = checkly_check_group.check-group-1.id
+  group_id = checkly_check_group.check-group-1.id
 }
 
 output "trigger_check-group-1-url" {

--- a/test.tf
+++ b/test.tf
@@ -68,6 +68,7 @@ resource "checkly_check" "api-check-2" {
     method           = "GET"
     url              = "https://api.checklyhq.com/public-stats"
     follow_redirects = true
+    skip_ssl         = false
 
     headers = {
       X-CUSTOM-1 = 1
@@ -151,6 +152,7 @@ resource "checkly_check" "api-check-3" {
     method           = "POST"
     url              = "https://jsonplaceholder.typicode.com/posts"
     follow_redirects = true
+    skip_ssl         = false
 
     headers = {
       Content-type = "application/json; charset=UTF-8"
@@ -207,6 +209,7 @@ resource "checkly_check" "api-check-4" {
 
   request {
     follow_redirects = false
+    skip_ssl         = true
     url              = "https://api.checklyhq.com/public-stats"
 
     basic_auth {
@@ -406,6 +409,7 @@ resource "checkly_check" "api-check-group-1_1" {
     method           = "GET"
     url              = "https://api.checklyhq.com/public-stats"
     follow_redirects = true
+    skip_ssl         = false
   }
 
   group_id    = checkly_check_group.check-group-1.id
@@ -427,6 +431,7 @@ resource "checkly_check" "api-check-group-1_2" {
     method           = "GET"
     url              = "https://api.checklyhq.com/public-stats"
     follow_redirects = true
+    skip_ssl         = false
   }
 
   group_id    = checkly_check_group.check-group-1.id


### PR DESCRIPTION
## Affected Components
* [X] Resources
* [X] Tests
* [ ] Docs
* [ ] Other

## Style
* [X] Terraform code is formatted with `terraform fmt`
* [X] Go code is formatted with `go fmt`

## Notes for the Reviewer
The create check API endpoint allows a new param : skipSSL.

> Resolves #112 
> Depends on https://github.com/checkly/checkly-go-sdk/pull/68