### PR TITLE
feat: add CHECKLY_API_SOURCE env variable

### DIFF
--- a/checkly/provider.go
+++ b/checkly/provider.go
@@ -84,7 +84,12 @@ func Provider() *schema.Provider {
 				client.SetAccountId(accountId)
 			}
 
-			client.SetChecklySource("TF")
+			checklyApiSource := os.Getenv("CHECKLY_API_SOURCE")
+			if checklyApiSource != "" {
+				client.SetChecklySource(checklyApiSource)
+			} else {
+				client.SetChecklySource("TF")
+			}
 
 			return client, nil
 		},


### PR DESCRIPTION
## Affected Components
* [ ] Resources
* [ ] Tests
* [ ] Docs
* [x] Other

## Style
* [x] Terraform code is formatted with `terraform fmt`
* [x] Go code is formatted with `go fmt`


## Notes for the Reviewer
Add the `CHECKLY_API_SOURCE` environment variable. 
This is needed mostly to allow Pulumi provider sets its own source.

> Resolves https://github.com/checkly/terraform-provider-checkly/issues/119