### PR TITLE
chore: flag sslCertificates as deprecated

### DIFF
--- a/checkly/resource_check.go
+++ b/checkly/resource_check.go
@@ -244,8 +244,9 @@ func resourceCheck() *schema.Resource {
 							},
 						},
 						"ssl_certificates": {
-							Type:     schema.TypeSet,
-							Optional: true,
+							Type:       schema.TypeSet,
+							Optional:   true,
+							Deprecated: "The property `ssl_certificates` is deprecated and it's ignored by the Checkly Public API. It will be removed in a future version.",
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"enabled": {

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -62,6 +62,23 @@ resource "checkly_check_group" "first-group" {
   concurrency = 3
   locations = [ "eu-west-1" ]
 }
+
+resource "checkly_check" "first-api-check" {
+  name      = "API check 1"
+  type      = "API"
+  activated = true
+  muted     = false
+  frequency = 720
+
+  request {
+    method           = "GET"
+    url              = "https://api.checklyhq.com/public-stats"
+  }
+
+  group_id    = checkly_check_group.first-group.id
+  group_order = 1
+
+}
 ```
 
 6. Now run `$ terraform init` to setup a new project. Then use `$ terraform plan` followed by `$ terraform apply` to deploy your monitoring.

--- a/docs/resources/check.md
+++ b/docs/resources/check.md
@@ -248,7 +248,7 @@ Optional:
 - `escalation_type` (String) Determines what type of escalation to use. Possible values are `RUN_BASED` or `TIME_BASED`.
 - `reminders` (Block Set) (see [below for nested schema](#nestedblock--alert_settings--reminders))
 - `run_based_escalation` (Block Set) (see [below for nested schema](#nestedblock--alert_settings--run_based_escalation))
-- `ssl_certificates` (Block Set) (see [below for nested schema](#nestedblock--alert_settings--ssl_certificates))
+- `ssl_certificates` (Block Set, Deprecated) (see [below for nested schema](#nestedblock--alert_settings--ssl_certificates))
 - `time_based_escalation` (Block Set) (see [below for nested schema](#nestedblock--alert_settings--time_based_escalation))
 
 <a id="nestedblock--alert_settings--reminders"></a>


### PR DESCRIPTION
## Affected Components
* [x] Resources
* [ ] Tests
* [x] Docs
* [ ] Other

## Style
* [x] Terraform code is formatted with `terraform fmt`
* [x] Go code is formatted with `go fmt`

## Notes for the Reviewer
Flag `sslCertificates` as depreacted

> Resolves #136 