### PR TITLE
refactor: remove extra `required` fields in maintenance window resource

### DIFF
--- a/checkly/resource_maintenance_window.go
+++ b/checkly/resource_maintenance_window.go
@@ -66,7 +66,7 @@ func resourceMaintenanceWindow() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Default:     nil,
-				Description: "The date on which the maintenance window window should stop repeating.",
+				Description: "The date on which the maintenance window should stop repeating.",
 			},
 			"tags": {
 				Type:     schema.TypeSet,

--- a/checkly/resource_maintenance_window.go
+++ b/checkly/resource_maintenance_window.go
@@ -37,9 +37,23 @@ func resourceMaintenanceWindow() *schema.Resource {
 				Description: "The end date of the maintenance window.",
 			},
 			"repeat_unit": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Default:     nil,
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  nil,
+				ValidateFunc: func(value interface{}, key string) (warns []string, errs []error) {
+					v := value.(string)
+					isValid := false
+					options := []string{"DAY", "WEEK", "MONTH"}
+					for _, option := range options {
+						if v == option {
+							isValid = true
+						}
+					}
+					if !isValid {
+						errs = append(errs, fmt.Errorf("%q must be one of %v, got %s", key, options, v))
+					}
+					return warns, errs
+				},
 				Description: "The repeat cadence for the maintenance window. Possible values `DAY`, `WEEK` and `MONTH`.",
 			},
 			"repeat_interval": {
@@ -59,6 +73,9 @@ func resourceMaintenanceWindow() *schema.Resource {
 				Optional: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
+				},
+				DefaultFunc: func() (interface{}, error) {
+					return []tfMap{}, nil
 				},
 				Description: "The names of the checks and groups maintenance window should apply to.",
 			},

--- a/checkly/resource_maintenance_window.go
+++ b/checkly/resource_maintenance_window.go
@@ -38,18 +38,21 @@ func resourceMaintenanceWindow() *schema.Resource {
 			},
 			"repeat_unit": {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
+				Default:     nil,
 				Description: "The repeat cadence for the maintenance window. Possible values `DAY`, `WEEK` and `MONTH`.",
-			},
-			"repeat_ends_at": {
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: "The date on which the maintenance window window should stop repeating.",
 			},
 			"repeat_interval": {
 				Type:        schema.TypeInt,
-				Required:    true,
+				Optional:    true,
+				Default:     nil,
 				Description: "The repeat interval of the maintenance window from the first occurrence.",
+			},
+			"repeat_ends_at": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     nil,
+				Description: "The date on which the maintenance window window should stop repeating.",
 			},
 			"tags": {
 				Type:     schema.TypeSet,

--- a/demo/maintenance_windows.tf
+++ b/demo/maintenance_windows.tf
@@ -1,12 +1,19 @@
-# Maintenance windows  example
+# Simple Maintenance windows example
 resource "checkly_maintenance_windows" "maintenance-1" {
-  name            = "string"
-  starts_at       = "2014-08-24T00:00:00.000Z"
-  ends_at         = "2014-08-25T00:00:00.000Z"
+  name            = "MW Simple"
+  starts_at       = "2028-08-24T00:00:00.000Z"
+  ends_at         = "2028-08-25T00:00:00.000Z"
+}
+
+# Complete Maintenance windows example
+resource "checkly_maintenance_windows" "maintenance-2" {
+  name            = "MW Complete"
+  starts_at       = "2022-05-24T00:00:00.000Z"
+  ends_at         = "2022-05-25T00:00:00.000Z"
   repeat_unit     = "MONTH"
-  repeat_ends_at  = "2014-08-24T00:00:00.000Z"
+  repeat_ends_at  = "2028-08-24T00:00:00.000Z"
   repeat_interval = 1
   tags = [
-    "string",
+    "checks",
   ]
 }

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -62,6 +62,23 @@ resource "checkly_check_group" "first-group" {
   concurrency = 3
   locations = [ "eu-west-1" ]
 }
+
+resource "checkly_check" "first-api-check" {
+  name      = "API check 1"
+  type      = "API"
+  activated = true
+  muted     = false
+  frequency = 720
+
+  request {
+    method           = "GET"
+    url              = "https://api.checklyhq.com/public-stats"
+  }
+
+  group_id    = checkly_check_group.first-group.id
+  group_order = 1
+
+}
 ```
 
 6. Now run `$ terraform init` to setup a new project. Then use `$ terraform plan` followed by `$ terraform apply` to deploy your monitoring.

--- a/docs/resources/maintenance_windows.md
+++ b/docs/resources/maintenance_windows.md
@@ -33,14 +33,14 @@ resource "checkly_maintenance_windows" "maintenance-1" {
 
 - `ends_at` (String) The end date of the maintenance window.
 - `name` (String) The maintenance window name.
-- `repeat_ends_at` (String) The date on which the maintenance window window should stop repeating.
-- `repeat_interval` (Number) The repeat interval of the maintenance window from the first occurrence.
-- `repeat_unit` (String) The repeat cadence for the maintenance window. Possible values `DAY`, `WEEK` and `MONTH`.
 - `starts_at` (String) The start date of the maintenance window.
 
 ### Optional
 
 - `id` (String) The ID of this resource.
+- `repeat_ends_at` (String) The date on which the maintenance window window should stop repeating.
+- `repeat_interval` (Number) The repeat interval of the maintenance window from the first occurrence.
+- `repeat_unit` (String) The repeat cadence for the maintenance window. Possible values `DAY`, `WEEK` and `MONTH`.
 - `tags` (Set of String) The names of the checks and groups maintenance window should apply to.
 
 

--- a/docs/resources/maintenance_windows.md
+++ b/docs/resources/maintenance_windows.md
@@ -3,7 +3,7 @@
 page_title: "checkly_maintenance_windows Resource - terraform-provider-checkly"
 subcategory: ""
 description: |-
-  
+
 ---
 
 # checkly_maintenance_windows (Resource)
@@ -38,7 +38,7 @@ resource "checkly_maintenance_windows" "maintenance-1" {
 ### Optional
 
 - `id` (String) The ID of this resource.
-- `repeat_ends_at` (String) The date on which the maintenance window window should stop repeating.
+- `repeat_ends_at` (String) The date on which the maintenance window should stop repeating.
 - `repeat_interval` (Number) The repeat interval of the maintenance window from the first occurrence.
 - `repeat_unit` (String) The repeat cadence for the maintenance window. Possible values `DAY`, `WEEK` and `MONTH`.
 - `tags` (Set of String) The names of the checks and groups maintenance window should apply to.

--- a/go.mod
+++ b/go.mod
@@ -11,3 +11,4 @@ require (
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/oklog/run v1.1.0 // indirect
 )
+


### PR DESCRIPTION
## Affected Components
* [x] Resources
* [ ] Tests
* [ ] Docs
* [ ] Other

## Style
* [x] Terraform code is formatted with `terraform fmt`
* [x] Go code is formatted with `go fmt`

## Notes for the Reviewer
- Remove unneeded required from maintenance window resource.
- Add better maintenance window examples
- Update docs

> Depends on GO SDK Release 
> Resolves #140 