### PR TITLE
Deprecate `ssl_certificates` from Groups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ dist/*
 .vscode/
 .local
 *.tfvars
+__debug_bin
+local/*

--- a/checkly/resource_check.go
+++ b/checkly/resource_check.go
@@ -140,6 +140,7 @@ func resourceCheck() *schema.Resource {
 			"ssl_check": {
 				Type:        schema.TypeBool,
 				Optional:    true,
+				Deprecated:  "The property `ssl_check` is deprecated and it's ignored by the Checkly Public API. It will be removed in a future version.",
 				Description: "Determines if the SSL certificate should be validated for expiry.",
 			},
 			"setup_snippet_id": {

--- a/checkly/resource_check.go
+++ b/checkly/resource_check.go
@@ -258,7 +258,6 @@ func resourceCheck() *schema.Resource {
 									"alert_threshold": {
 										Type:     schema.TypeInt,
 										Optional: true,
-										Default:  3,
 										ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
 											v := val.(int)
 											valid := false

--- a/checkly/resource_check_group.go
+++ b/checkly/resource_check_group.go
@@ -171,8 +171,9 @@ func resourceCheckGroup() *schema.Resource {
 							},
 						},
 						"ssl_certificates": {
-							Type:     schema.TypeSet,
-							Optional: true,
+							Type:       schema.TypeSet,
+							Optional:   true,
+							Deprecated: "The property `ssl_certificates` is deprecated and it's ignored by the Checkly Public API. It will be removed in a future version.",
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"enabled": {

--- a/checkly/resource_check_group.go
+++ b/checkly/resource_check_group.go
@@ -185,7 +185,6 @@ func resourceCheckGroup() *schema.Resource {
 									"alert_threshold": {
 										Type:     schema.TypeInt,
 										Optional: true,
-										Default:  3,
 										ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
 											v := val.(int)
 											valid := false

--- a/checkly/resource_check_group_test.go
+++ b/checkly/resource_check_group_test.go
@@ -442,7 +442,6 @@ const testCheckGroup_full = `
 	  }
 	  ssl_certificates {
 		enabled         = false
-		alert_threshold = 0
 	  }
 	  reminders {
 		amount   = 2

--- a/checkly/resource_check_group_test.go
+++ b/checkly/resource_check_group_test.go
@@ -291,7 +291,7 @@ func TestAccCheckGroupFull(t *testing.T) {
 				testCheckResourceAttrExpr(
 					"checkly_check_group.test",
 					"alert_settings.*.ssl_certificates.*.enabled",
-					"true",
+					"false",
 				),
 				testCheckResourceAttrExpr(
 					"checkly_check_group.test",
@@ -391,9 +391,9 @@ const testCheckGroup_withApiDefaults = `
 		activated   = true
 		muted       = false
 		concurrency = 3
-		locations   = [ 
-			"eu-west-1", 
-			"eu-west-2" 
+		locations   = [
+			"eu-west-1",
+			"eu-west-2"
 		]
 		api_check_defaults {
 			url = "http://api.example.com/"
@@ -441,8 +441,8 @@ const testCheckGroup_full = `
 		minutes_failing_threshold = 5
 	  }
 	  ssl_certificates {
-		enabled         = true
-		alert_threshold = 30
+		enabled         = false
+		alert_threshold = 0
 	  }
 	  reminders {
 		amount   = 2

--- a/checkly/resource_check_test.go
+++ b/checkly/resource_check_test.go
@@ -530,8 +530,8 @@ const apiCheck_full = `
 		failed_run_threshold = 1
 	  }
 	  ssl_certificates {
-		alert_threshold = 30
-		enabled         = true
+		alert_threshold = 0
+		enabled         = false
 	  }
 	  time_based_escalation {
 		minutes_failing_threshold = 5

--- a/checkly/resource_check_test.go
+++ b/checkly/resource_check_test.go
@@ -530,7 +530,6 @@ const apiCheck_full = `
 		failed_run_threshold = 1
 	  }
 	  ssl_certificates {
-		alert_threshold = 0
 		enabled         = false
 	  }
 	  time_based_escalation {

--- a/checkly/resource_check_test.go
+++ b/checkly/resource_check_test.go
@@ -40,7 +40,6 @@ func TestAccBrowserCheckInvalidInputs(t *testing.T) {
 		activated                 = "invalid"
 		should_fail               = "invalid"
 		double_check              = "invalid"
-		ssl_check                 = "invalid"
 		use_global_alert_settings = "invalid"
 		locations = "invalid"
 		script = 4
@@ -57,10 +56,6 @@ func TestAccBrowserCheckInvalidInputs(t *testing.T) {
 		{
 			Config:      config,
 			ExpectError: regexp.MustCompile(`Inappropriate value for attribute "should_fail"`),
-		},
-		{
-			Config:      config,
-			ExpectError: regexp.MustCompile(`Inappropriate value for attribute "ssl_check"`),
 		},
 		{
 			Config:      config,
@@ -363,7 +358,7 @@ var wantCheck = checkly.Check{
 		"foo",
 		"bar",
 	},
-	SSLCheck:            true,
+	SSLCheck:            false,
 	LocalSetupScript:    "bogus",
 	LocalTearDownScript: "bogus",
 	AlertSettings: checkly.AlertSettings{
@@ -436,7 +431,6 @@ const browserCheck_basic = `
 		should_fail               = false
 		frequency                 = 720
 		double_check              = true
-		ssl_check                 = true
 		use_global_alert_settings = true
 		locations                 = [ "us-east-1", "eu-central-1" ]
 		tags                      = [ "browser", "e2e" ]
@@ -475,7 +469,6 @@ const apiCheck_full = `
 	activated              = true
 	muted                  = true
 	double_check           = true
-	ssl_check              = false
 	degraded_response_time = 15000
 	max_response_time      = 30000
 	environment_variables  = null

--- a/demo/api-checks.tf
+++ b/demo/api-checks.tf
@@ -114,10 +114,6 @@ resource "checkly_check" "api-check-2" {
     run_based_escalation {
       failed_run_threshold = 1
     }
-    ssl_certificates {
-      alert_threshold = 30
-      enabled         = true
-    }
     time_based_escalation {
       minutes_failing_threshold = 5
     }

--- a/demo/api-checks.tf
+++ b/demo/api-checks.tf
@@ -45,7 +45,6 @@ resource "checkly_check" "api-check-2" {
   activated              = true
   muted                  = true
   double_check           = true
-  ssl_check              = false
   degraded_response_time = 15000
   max_response_time      = 30000
   environment_variables  = null

--- a/demo/browser-checks.tf
+++ b/demo/browser-checks.tf
@@ -6,7 +6,6 @@ resource "checkly_check" "browser-check-1" {
   should_fail               = false
   frequency                 = 10
   double_check              = true
-  ssl_check                 = true
   use_global_alert_settings = true
   locations = [
     "us-west-1"
@@ -34,7 +33,6 @@ resource "checkly_check" "browser-check-2" {
   should_fail               = false
   frequency                 = 15
   double_check              = true
-  ssl_check                 = true
   use_global_alert_settings = true
 
   script = "console.log('test')"

--- a/demo/groups.tf
+++ b/demo/groups.tf
@@ -86,11 +86,6 @@ resource "checkly_check_group" "check-group-3" {
       minutes_failing_threshold = 5
     }
 
-    ssl_certificates {
-      enabled         = true
-      alert_threshold = 30
-    }
-
     reminders {
       amount   = 2
       interval = 5

--- a/docs/resources/check.md
+++ b/docs/resources/check.md
@@ -68,11 +68,6 @@ resource "checkly_check" "example-check-2" {
       minutes_failing_threshold = 5
     }
 
-    ssl_certificates {
-      enabled         = true
-      alert_threshold = 30
-    }
-
     reminders {
       amount = 1
     }

--- a/docs/resources/check_group.md
+++ b/docs/resources/check_group.md
@@ -71,11 +71,6 @@ resource "checkly_check_group" "test-group1" {
       minutes_failing_threshold = 5
     }
 
-    ssl_certificates {
-      enabled         = true
-      alert_threshold = 30
-    }
-
     reminders {
       amount   = 2
       interval = 5
@@ -168,7 +163,7 @@ Optional:
 - `escalation_type` (String) Determines what type of escalation to use. Possible values are `RUN_BASED` or `TIME_BASED`.
 - `reminders` (Block Set) (see [below for nested schema](#nestedblock--alert_settings--reminders))
 - `run_based_escalation` (Block Set) (see [below for nested schema](#nestedblock--alert_settings--run_based_escalation))
-- `ssl_certificates` (Block Set) (see [below for nested schema](#nestedblock--alert_settings--ssl_certificates))
+- `ssl_certificates` (Block Set, Deprecated) (see [below for nested schema](#nestedblock--alert_settings--ssl_certificates))
 - `time_based_escalation` (Block Set) (see [below for nested schema](#nestedblock--alert_settings--time_based_escalation))
 
 <a id="nestedblock--alert_settings--reminders"></a>

--- a/docs/resources/maintenance_windows.md
+++ b/docs/resources/maintenance_windows.md
@@ -3,7 +3,7 @@
 page_title: "checkly_maintenance_windows Resource - terraform-provider-checkly"
 subcategory: ""
 description: |-
-
+  
 ---
 
 # checkly_maintenance_windows (Resource)

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -26,7 +26,6 @@ resource "checkly_check" "example-check" {
   should_fail               = false
   frequency                 = 10
   double_check              = true
-  ssl_check                 = true
   use_global_alert_settings = true
 
   locations = [

--- a/examples/resources/checkly_check/resource.tf
+++ b/examples/resources/checkly_check/resource.tf
@@ -53,11 +53,6 @@ resource "checkly_check" "example-check-2" {
       minutes_failing_threshold = 5
     }
 
-    ssl_certificates {
-      enabled         = true
-      alert_threshold = 30
-    }
-
     reminders {
       amount = 1
     }

--- a/examples/resources/checkly_check/resource.tf
+++ b/examples/resources/checkly_check/resource.tf
@@ -6,7 +6,6 @@ resource "checkly_check" "example-check" {
   should_fail               = false
   frequency                 = 1
   double_check              = true
-  ssl_check                 = true
   use_global_alert_settings = true
 
   locations = [
@@ -100,7 +99,6 @@ resource "checkly_check" "browser-check-1" {
   should_fail               = false
   frequency                 = 10
   double_check              = true
-  ssl_check                 = true
   use_global_alert_settings = true
   locations = [
     "us-west-1"
@@ -135,7 +133,6 @@ resource "checkly_check" "browser-check-1" {
   should_fail               = false
   frequency                 = 10
   double_check              = true
-  ssl_check                 = true
   use_global_alert_settings = true
   locations = [
     "us-west-1"

--- a/examples/resources/checkly_check_group/resource.tf
+++ b/examples/resources/checkly_check_group/resource.tf
@@ -56,11 +56,6 @@ resource "checkly_check_group" "test-group1" {
       minutes_failing_threshold = 5
     }
 
-    ssl_certificates {
-      enabled         = true
-      alert_threshold = 30
-    }
-
     reminders {
       amount   = 2
       interval = 5


### PR DESCRIPTION
## Affected Components
* [x] Resources
* [x] Tests
* [x] Docs
* [ ] Tooling
* [ ] Other

## Pre-Requisites
* [x] Terraform code is formatted with `terraform fmt`
* [x] Go code is formatted with `go fmt`
* [x] `plan` & `apply` command of `demo/main.tf` file do not produce diffs

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
- Deprecate `ssl_certificates` from groups 
- Update tests and fixtures

> Resolves #116
