### PR TITLE
fix: always check for the correct escalation settings when parsing

### DIFF
--- a/checkly/resource_check_group.go
+++ b/checkly/resource_check_group.go
@@ -405,6 +405,17 @@ func resourceDataFromCheckGroup(g *checkly.Group, d *schema.ResourceData) error 
 	d.Set("activated", g.Activated)
 	d.Set("muted", g.Muted)
 	d.Set("locations", g.Locations)
+	d.Set("double_check", g.DoubleCheck)
+	d.Set("setup_snippet_id", g.SetupSnippetID)
+	d.Set("teardown_snippet_id", g.TearDownSnippetID)
+	d.Set("local_setup_script", g.LocalSetupScript)
+	d.Set("local_teardown_script", g.LocalTearDownScript)
+	d.Set("use_global_alert_settings", g.UseGlobalAlertSettings)
+	d.Set("alert_channel_subscription", g.AlertChannelSubscriptions)
+	d.Set("private_locations", g.PrivateLocations)
+
+	sort.Strings(g.Tags)
+	d.Set("tags", g.Tags)
 
 	environmentVariables := environmentVariablesFromSet(d.Get("environment_variable").([]interface{}))
 	if len(environmentVariables) > 0 {
@@ -413,14 +424,6 @@ func resourceDataFromCheckGroup(g *checkly.Group, d *schema.ResourceData) error 
 		return fmt.Errorf("error setting environment variables for resource %s: %s", d.Id(), err)
 	}
 
-	d.Set("double_check", g.DoubleCheck)
-	sort.Strings(g.Tags)
-	d.Set("tags", g.Tags)
-	d.Set("setup_snippet_id", g.SetupSnippetID)
-	d.Set("teardown_snippet_id", g.TearDownSnippetID)
-	d.Set("local_setup_script", g.LocalSetupScript)
-	d.Set("local_teardown_script", g.LocalTearDownScript)
-
 	if g.RuntimeID != nil {
 		d.Set("runtime_id", *g.RuntimeID)
 	}
@@ -428,12 +431,11 @@ func resourceDataFromCheckGroup(g *checkly.Group, d *schema.ResourceData) error 
 	if err := d.Set("alert_settings", setFromAlertSettings(g.AlertSettings)); err != nil {
 		return fmt.Errorf("error setting alert settings for resource %s: %s", d.Id(), err)
 	}
-	d.Set("use_global_alert_settings", g.UseGlobalAlertSettings)
+
 	if err := d.Set("api_check_defaults", setFromAPICheckDefaults(g.APICheckDefaults)); err != nil {
 		return fmt.Errorf("error setting request for resource %s: %s", d.Id(), err)
 	}
-	d.Set("alert_channel_subscription", g.AlertChannelSubscriptions)
-	d.Set("private_locations", g.PrivateLocations)
+
 	d.SetId(d.Id())
 	return nil
 }

--- a/checkly/resource_check_group_test.go
+++ b/checkly/resource_check_group_test.go
@@ -70,9 +70,6 @@ var wantGroup = checkly.Group{
 		RunBasedEscalation: checkly.RunBasedEscalation{
 			FailedRunThreshold: 1,
 		},
-		TimeBasedEscalation: checkly.TimeBasedEscalation{
-			MinutesFailingThreshold: 5,
-		},
 		Reminders: checkly.Reminders{
 			Amount:   0,
 			Interval: 5,
@@ -276,12 +273,6 @@ func TestAccCheckGroupFull(t *testing.T) {
 					"alert_settings.*.run_based_escalation.*.failed_run_threshold",
 					"1",
 				),
-
-				testCheckResourceAttrExpr(
-					"checkly_check_group.test",
-					"alert_settings.*.time_based_escalation.*.minutes_failing_threshold",
-					"5",
-				),
 				testCheckResourceAttrExpr(
 					"checkly_check_group.test",
 					"api_check_defaults.#",
@@ -421,9 +412,6 @@ const testCheckGroup_full = `
 	  run_based_escalation {
 		failed_run_threshold = 1
 	  }
-	  time_based_escalation {
-		minutes_failing_threshold = 5
-	  }
 	  reminders {
 		amount   = 2
 		interval = 5
@@ -431,41 +419,5 @@ const testCheckGroup_full = `
 	}
 	local_setup_script    = "setup-test"
 	local_teardown_script = "teardown-test"
-  }
-`
-
-const testCheck_groupWithChecks = `
-  resource "checkly_check" "test" {
-	name      = "test"
-	type      = "API"
-	activated = true
-	muted     = true
-	frequency = 720
-	locations = [ "eu-central-1", "us-east-2" ]
-	request {
-	  method           = "GET"
-	  url              = "https://api.checklyhq.com/public-stats"
-	  follow_redirects = true
-	}
-	group_id    = checkly_check_group.check-group-1.id
-	group_order = 1 #The group_order attribute specifies in which order the checks will be executed: 1, 2, 3, etc.
-  }
-`
-
-const testCheck_checkInGroup = `
-  resource "checkly_check" "test" {
-	name      = "test"
-	type      = "API"
-	activated = true
-	muted     = true
-	frequency = 720
-	locations = [ "eu-central-1", "us-east-2" ]
-	request {
-	  method           = "GET"
-	  url              = "https://api.checklyhq.com/public-stats"
-	  follow_redirects = true
-	}
-	group_id    = checkly_check_group.check-group-1.id
-	group_order = 2
   }
 `

--- a/checkly/resource_check_test.go
+++ b/checkly/resource_check_test.go
@@ -367,9 +367,6 @@ var wantCheck = checkly.Check{
 		RunBasedEscalation: checkly.RunBasedEscalation{
 			FailedRunThreshold: 1,
 		},
-		TimeBasedEscalation: checkly.TimeBasedEscalation{
-			MinutesFailingThreshold: 5,
-		},
 		Reminders: checkly.Reminders{
 			Interval: 5,
 		},
@@ -518,9 +515,6 @@ const apiCheck_full = `
 	  }
 	  run_based_escalation {
 		failed_run_threshold = 1
-	  }
-	  time_based_escalation {
-		minutes_failing_threshold = 5
 	  }
 	}
   }


### PR DESCRIPTION
## Affected Components
* [x] Resources
* [ ] Tests
* [ ] Docs
* [ ] Other

## Style
* [x] Terraform code is formatted with `terraform fmt`
* [x] Go code is formatted with `go fmt`

## Notes for the Reviewer
Dynamically check for escalation type whenever parsing resource to check (or check to resource)

> Resolves #194