### PR TITLE
fix: ensure private location icon has a default value

### DIFF
--- a/checkly/resource_private_locations.go
+++ b/checkly/resource_private_locations.go
@@ -33,6 +33,7 @@ func resourcePrivateLocation() *schema.Resource {
 			"icon": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				Default:	 "location",
 				Description: "Icon assigned to the private location.",
 			},
 			"keys": {

--- a/checkly/resource_private_locations_test.go
+++ b/checkly/resource_private_locations_test.go
@@ -25,7 +25,7 @@ func TestAccPrivateLocationSuccess(t *testing.T) {
 	config := `resource "checkly_private_location" "test" {
 		name     = "New Private Location"
 		slug_name   = "new-private-location"
-		icon       	= "location"
+		icon       	= "bell-fill"
 	}`
 	accTestCase(t, []resource.TestStep{
 		{
@@ -43,6 +43,35 @@ func TestAccPrivateLocationSuccess(t *testing.T) {
 				),
 				resource.TestCheckResourceAttr(
 					"checkly_private_location.test",
+					"icon",
+					"bell-fill",
+				),
+			),
+		},
+	})
+}
+
+func TestAccPrivateLocationDefaultIcon(t *testing.T) {
+	config := `resource "checkly_private_location" "without_icon" {
+		name     = "New Private Location"
+		slug_name   = "new-private-location"
+	}`
+	accTestCase(t, []resource.TestStep{
+		{
+			Config: config,
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr(
+					"checkly_private_location.without_icon",
+					"name",
+					"New Private Location",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_private_location.without_icon",
+					"slug_name",
+					"new-private-location",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_private_location.without_icon",
 					"icon",
 					"location",
 				),

--- a/demo/private_locations.tf
+++ b/demo/private_locations.tf
@@ -1,5 +1,4 @@
 resource "checkly_private_location" "location" {
   name      = "New Private Location"
   slug_name = "new-private-location"
-  icon      = "location"
 }

--- a/docs/resources/private_location.md
+++ b/docs/resources/private_location.md
@@ -3,7 +3,7 @@
 page_title: "checkly_private_location Resource - terraform-provider-checkly"
 subcategory: ""
 description: |-
-  
+
 ---
 
 # checkly_private_location (Resource)
@@ -17,7 +17,6 @@ description: |-
 resource "checkly_private_location" "location" {
   name = "New Private Location"
   slug_name = "new-private-location"
-  icon = "location"
 }
 ```
 
@@ -26,11 +25,9 @@ resource "checkly_private_location" "location" {
 
 ### Required
 
-- `name` (String) 
+- `name` (String)
 - `slug_name` (String)
 
 ### Optional
 
 - `icon` (String) The icon that will represent the private location.
-
-

--- a/examples/resources/checkly_private_location/resource.tf
+++ b/examples/resources/checkly_private_location/resource.tf
@@ -1,5 +1,4 @@
 resource "checkly_private_location" "location" {
   name          = "New Private Location"
   slug_name     = "new-private-location"
-  icon          = "location"
 }


### PR DESCRIPTION
## Affected Components
* [x] Resources
* [ ] Test
* [ ] Docs
* [ ] Tooling
* [ ] Other

## Pre-Requisites
* [ ] Terraform code is formatted with `terraform fmt`
* [ ] Go code is formatted with `go fmt`
* [ ] `plan` & `apply` command of `demo/main.tf` file do not produce diffs

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

Otherwise, the private location never reconciles when the icon input isn't used.

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
