### PR TITLE
feat: support private dashboard creation

### DIFF
--- a/checkly/resource_dashboard.go
+++ b/checkly/resource_dashboard.go
@@ -138,6 +138,21 @@ func resourceDashboard() *schema.Resource {
 				Default:     false,
 				Description: "Set when to use AND operator for fetching dashboard tags.",
 			},
+			"is_private": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "Set your dashboard as private and generate key.",
+			},
+			"keys": {
+				Type:      schema.TypeSet,
+				Computed:  true,
+				Sensitive: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Description: "Dashboard API key.",
+			},
 		},
 	}
 }
@@ -158,6 +173,7 @@ func dashboardFromResourceData(d *schema.ResourceData) (checkly.Dashboard, error
 		HideTags:           d.Get("hide_tags").(bool),
 		Width:              d.Get("width").(string),
 		UseTagsAndOperator: d.Get("use_tags_and_operator").(bool),
+		IsPrivate:          d.Get("is_private").(bool),
 		Tags:               stringsFromSet(d.Get("tags").(*schema.Set)),
 	}
 
@@ -182,6 +198,7 @@ func resourceDataFromDashboard(s *checkly.Dashboard, d *schema.ResourceData) err
 	d.Set("tags", s.Tags)
 	d.Set("width", s.Width)
 	d.Set("use_tags_and_operator", s.UseTagsAndOperator)
+	d.Set("is_private", s.IsPrivate)
 	return nil
 }
 
@@ -199,6 +216,9 @@ func resourceDashboardCreate(d *schema.ResourceData, client interface{}) error {
 	}
 
 	d.SetId(result.DashboardID)
+
+	var keys = []string{result.Keys[0].RawKey}
+	d.Set("keys", keys)
 	return resourceDashboardRead(d, client)
 }
 

--- a/checkly/resource_dashboard.go
+++ b/checkly/resource_dashboard.go
@@ -144,11 +144,11 @@ func resourceDashboard() *schema.Resource {
 				Default:     false,
 				Description: "Set your dashboard as private and generate key.",
 			},
-			// moving to TypeString here since https://github.com/hashicorp/terraform-plugin-sdk/issues/792
+			// moving to TypeString here https://github.com/hashicorp/terraform-plugin-sdk/issues/792
 			"key": {
-				Type:      schema.TypeString,
-				Computed:  true,
-				Sensitive: true,
+				Type:        schema.TypeString,
+				Computed:    true,
+				Sensitive:   true,
 				Description: "The access key when the dashboard is private.",
 			},
 		},
@@ -201,7 +201,7 @@ func resourceDataFromDashboard(s *checkly.Dashboard, d *schema.ResourceData) err
 	// if the dashboard is private, we either do nothing
 	// or set the key to a new value if there is any
 	if s.IsPrivate {
-	  if len(s.Keys) > 0 {
+		if len(s.Keys) > 0 {
 			d.Set("key", s.Keys[0].RawKey)
 		}
 	} else {

--- a/checkly/resource_dashboard.go
+++ b/checkly/resource_dashboard.go
@@ -217,8 +217,10 @@ func resourceDashboardCreate(d *schema.ResourceData, client interface{}) error {
 
 	d.SetId(result.DashboardID)
 
-	var keys = []string{result.Keys[0].RawKey}
-	d.Set("keys", keys)
+	if dashboard.IsPrivate {
+		var keys = []string{result.Keys[0].RawKey}
+		d.Set("keys", keys)
+	}
 	return resourceDashboardRead(d, client)
 }
 

--- a/docs/resources/dashboard.md
+++ b/docs/resources/dashboard.md
@@ -44,6 +44,7 @@ resource "checkly_dashboard" "dashboard_1" {
 - `favicon` (String) A URL pointing to an image file to use as browser favicon.
 - `header` (String) A piece of text displayed at the top of your dashboard.
 - `hide_tags` (Boolean) Show or hide the tags on the dashboard.
+- `is_private` (Boolean) Set your dashboard as private and generate key.
 - `link` (String) A link to for the dashboard logo.
 - `logo` (String) A URL pointing to an image file to use for the dashboard logo.
 - `paginate` (Boolean) Determines if pagination is on or off.
@@ -51,11 +52,11 @@ resource "checkly_dashboard" "dashboard_1" {
 - `refresh_rate` (Number) How often to refresh the dashboard in seconds. Possible values `60`, '300' and `600`.
 - `tags` (Set of String) A list of one or more tags that filter which checks to display on the dashboard.
 - `use_tags_and_operator` (Boolean) Set when to use AND operator for fetching dashboard tags.
-- `is_private` (Boolean) Set your dashboard as private and generate key.
 - `width` (String) Determines whether to use the full screen or focus in the center. Possible values `FULL` and `960PX`.
 
 ### Read-Only
 
 - `id` (String) The ID of this resource.
-- `keys` (Set of String, Sensitive) Dashboard API keys.
+- `key` (String, Sensitive) The access key when the dashboard is private.
+
 

--- a/docs/resources/dashboard.md
+++ b/docs/resources/dashboard.md
@@ -51,10 +51,11 @@ resource "checkly_dashboard" "dashboard_1" {
 - `refresh_rate` (Number) How often to refresh the dashboard in seconds. Possible values `60`, '300' and `600`.
 - `tags` (Set of String) A list of one or more tags that filter which checks to display on the dashboard.
 - `use_tags_and_operator` (Boolean) Set when to use AND operator for fetching dashboard tags.
+- `is_private` (Boolean) Set your dashboard as private and generate key.
 - `width` (String) Determines whether to use the full screen or focus in the center. Possible values `FULL` and `960PX`.
 
 ### Read-Only
 
 - `id` (String) The ID of this resource.
-
+- `keys` (Set of String, Sensitive) Dashboard API keys.
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/aws/aws-sdk-go v1.44.122 // indirect
-	github.com/checkly/checkly-go-sdk v1.6.3
+	github.com/checkly/checkly-go-sdk v1.6.4
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/google/go-cmp v0.5.9
 	github.com/gruntwork-io/terratest v0.41.16

--- a/go.sum
+++ b/go.sum
@@ -231,8 +231,8 @@ github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kB
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/checkly/checkly-go-sdk v1.6.3 h1:+9PongdPyORBmUbzBpwZBCANEr7og/RTnnt9gHhoamk=
-github.com/checkly/checkly-go-sdk v1.6.3/go.mod h1:Pd6tBOggAe41NnCU5KwqA8JvD6J20/IctszT2E0AvHo=
+github.com/checkly/checkly-go-sdk v1.6.4 h1:tV/iT9dLRP1yWJyYO9YayHtXVTujyc8/nfYOfW8lfGU=
+github.com/checkly/checkly-go-sdk v1.6.4/go.mod h1:Pd6tBOggAe41NnCU5KwqA8JvD6J20/IctszT2E0AvHo=
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=


### PR DESCRIPTION
## Affected Components
* [X] Resources
* [ ] Test
* [X] Docs
* [ ] Tooling
* [ ] Other

## Pre-Requisites
* [X] Terraform code is formatted with `terraform fmt`
* [X] Go code is formatted with `go fmt`
* [X] `plan` & `apply` command of `demo/main.tf` file do not produce diffs

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->
Add isPrivate and Keys property to Dashboard resource, this allows user to receive the password when creating a private dashboard using the provider. This uses the same behavior as create Private Location.

Testing steps:

1) On /demo/dashboard.tf add is_private as true
2) Run terraform plan / terraform apply
3) You will see the key on your terraform state
