### PR TITLE
chore: add ssl_check_domain property [sc-0]

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -5,6 +5,12 @@ chip=amd64
 ifeq ($(shell uname -m), arm64)
   chip=arm64
 endif
+ifeq ($(shell uname -s),Linux)
+  os="linux"
+endif
+ifeq ($(shell uname -s),Darwin)
+  os="darwin"
+endif
 
 # Run acceptance tests
 .PHONY: testacc
@@ -18,9 +24,9 @@ dev:
 	# for dev purposes only, build the provider and install
 	# it as dev/checkly/check + version number
 	go build -o terraform-provider-checkly
-	mkdir -p ~/.terraform.d/plugins/dev/checkly/checkly/${version}/darwin_${chip}/
+	mkdir -p ~/.terraform.d/plugins/dev/checkly/checkly/${version}/${os}_${chip}/
 	chmod +x terraform-provider-checkly
-	mv terraform-provider-checkly ~/.terraform.d/plugins/dev/checkly/checkly/${version}/darwin_${chip}/terraform-provider-checkly_v${version}
+	mv terraform-provider-checkly ~/.terraform.d/plugins/dev/checkly/checkly/${version}/${os}_${chip}/terraform-provider-checkly_v${version}
 	cd demo && rm -f .terraform.lock.hcl
 	cd demo && TF_LOG=TRACE terraform init -upgrade
 	cd local && rm -f .terraform.lock.hcl

--- a/checkly/resource_check.go
+++ b/checkly/resource_check.go
@@ -541,6 +541,10 @@ func resourceDataFromCheck(c *checkly.Check, d *schema.ResourceData) error {
 		d.Set("runtime_id", *c.RuntimeID)
 	}
 
+	if c.SSLCheckDomain != "" {
+		d.Set("ssl_check_domain", c.SSLCheckDomain)
+	}
+
 	environmentVariables := environmentVariablesFromSet(d.Get("environment_variable").([]interface{}))
 	if len(environmentVariables) > 0 {
 		d.Set("environment_variable", c.EnvironmentVariables)

--- a/checkly/resource_check.go
+++ b/checkly/resource_check.go
@@ -713,6 +713,10 @@ func checkFromResourceData(d *schema.ResourceData) (checkly.Check, error) {
 		if check.Frequency == 0 && (check.FrequencyOffset != 10 && check.FrequencyOffset != 20 && check.FrequencyOffset != 30) {
 			return check, errors.New("when property frequency is 0, frequency_offset must be 10, 20 or 30")
 		}
+
+		if check.SSLCheckDomain != "" {
+			return check, errors.New("ssl_check_domain is allowed only for Browser checks")
+		}
 	}
 
 	if check.Type == checkly.TypeBrowser && check.Frequency == 0 {

--- a/checkly/resource_check.go
+++ b/checkly/resource_check.go
@@ -541,8 +541,9 @@ func resourceDataFromCheck(c *checkly.Check, d *schema.ResourceData) error {
 		d.Set("runtime_id", *c.RuntimeID)
 	}
 
-	if c.SSLCheckDomain != "" {
-		d.Set("ssl_check_domain", c.SSLCheckDomain)
+	// ssl_check_domain is only supported for Browser checks
+	if c.Type == "BROWSER" && c.SSLCheckDomain != "" {
+		d.Set("ssl_check_domain", c.Type)
 	}
 
 	environmentVariables := environmentVariablesFromSet(d.Get("environment_variable").([]interface{}))

--- a/checkly/resource_check.go
+++ b/checkly/resource_check.go
@@ -165,6 +165,11 @@ func resourceCheck() *schema.Resource {
 				Deprecated:  "The property `ssl_check` is deprecated and it's ignored by the Checkly Public API. It will be removed in a future version.",
 				Description: "Determines if the SSL certificate should be validated for expiry.",
 			},
+			"ssl_check_domain": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "A valid fully qualified domain name (FQDN) to check its SSL certificate.",
+			},
 			"setup_snippet_id": {
 				Type:        schema.TypeInt,
 				Optional:    true,
@@ -672,6 +677,7 @@ func checkFromResourceData(d *schema.ResourceData) (checkly.Check, error) {
 		DoubleCheck:               d.Get("double_check").(bool),
 		Tags:                      stringsFromSet(d.Get("tags").(*schema.Set)),
 		SSLCheck:                  d.Get("ssl_check").(bool),
+		SSLCheckDomain:            d.Get("ssl_check_domain").(string),
 		SetupSnippetID:            int64(d.Get("setup_snippet_id").(int)),
 		TearDownSnippetID:         int64(d.Get("teardown_snippet_id").(int)),
 		LocalSetupScript:          d.Get("local_setup_script").(string),

--- a/demo/browser-checks.tf
+++ b/demo/browser-checks.tf
@@ -11,7 +11,7 @@ resource "checkly_check" "browser-check-1" {
     "us-west-1"
   ]
 
-  runtime_id = "2020.01"
+  runtime_id = "2023.02"
 
   script = <<EOT
 const assert = require("chai").assert;

--- a/demo/versions.tf
+++ b/demo/versions.tf
@@ -10,17 +10,17 @@ terraform {
     }
   }
 }
-variable "api_key" {
+variable "checkly_api_key" {
 }
 
-variable "account_id" {
+variable "checkly_account_id" {
 }
 
-variable "api_url" {
+variable "checkly_api_url" {
 }
 
 provider "checkly" {
-  api_key    = var.api_key
-  account_id = var.account_id
-  api_url    = var.api_url
+  api_key    = var.checkly_api_key
+  account_id = var.checkly_account_id
+  api_url    = var.checkly_api_url
 }

--- a/docs/resources/check.md
+++ b/docs/resources/check.md
@@ -218,6 +218,7 @@ resource "checkly_check" "example_check" {
 - `setup_snippet_id` (Number) An ID reference to a snippet to use in the setup phase of an API check.
 - `should_fail` (Boolean) Allows to invert the behaviour of when a check is considered to fail. Allows for validating error status like 404.
 - `ssl_check` (Boolean, Deprecated) Determines if the SSL certificate should be validated for expiry.
+- `ssl_check_domain` (String) A valid fully qualified domain name (FQDN) to check its SSL certificate.
 - `tags` (Set of String) A list of tags for organizing and filtering checks.
 - `teardown_snippet_id` (Number) An ID reference to a snippet to use in the teardown phase of an API check.
 - `use_global_alert_settings` (Boolean) When true, the account level alert settings will be used, not the alert setting defined on this check.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/aws/aws-sdk-go v1.44.122 // indirect
-	github.com/checkly/checkly-go-sdk v1.6.6
+	github.com/checkly/checkly-go-sdk v1.6.7
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/google/go-cmp v0.5.9
 	github.com/gruntwork-io/terratest v0.41.16

--- a/go.sum
+++ b/go.sum
@@ -231,10 +231,8 @@ github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kB
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/checkly/checkly-go-sdk v1.6.5 h1:J0hIl8zbiG7GObXXmwkXw/63IRXdYu9anr6oXJC04K8=
-github.com/checkly/checkly-go-sdk v1.6.5/go.mod h1:Pd6tBOggAe41NnCU5KwqA8JvD6J20/IctszT2E0AvHo=
-github.com/checkly/checkly-go-sdk v1.6.6 h1:IFxGxCx53chRG2SoTLLx8D96VA1/eiQd2+b9KVwdDJc=
-github.com/checkly/checkly-go-sdk v1.6.6/go.mod h1:Pd6tBOggAe41NnCU5KwqA8JvD6J20/IctszT2E0AvHo=
+github.com/checkly/checkly-go-sdk v1.6.7 h1:OhTsFwFKZYV9LsYyV1SuoU0Ql113Zk1D+JBTt+uVm7c=
+github.com/checkly/checkly-go-sdk v1.6.7/go.mod h1:Pd6tBOggAe41NnCU5KwqA8JvD6J20/IctszT2E0AvHo=
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=


### PR DESCRIPTION
## Affected Components
* [x] Resources
* [ ] Tests
* [ ] Docs
* [ ] Other

## Style
* [x] Terraform code is formatted with `terraform fmt`
* [x] Go code is formatted with `go fmt`

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
Following what was asked in this [thread](https://checklyhq.slack.com/archives/C024ZAJ938S/p1690276802718249) and this [issue](https://github.com/checkly/terraform-provider-checkly/issues/263), this PRs adds the `SSLCheckDomain` property into the `check` resource.

This PRs makes `make dev` command OS agnostic (for `darwin` and `linux`). This affects only the local development environment.
<!-- Anything the reviewer should pay extra attention to. -->

## New Dependency Submission
> Depends on https://github.com/checkly/checkly-go-sdk/pull/112
> Depends on https://github.com/checkly/checkly-backend/pull/4579
<!-- Please explain here why we need the new dependency. -->
