### PR TITLE
feat: add support for retry strategies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,7 +151,7 @@ terraform {
 provider "checkly" {
   api_key = var.checkly_api_key
   account_id = var.checkly_account_id
-  
+}
 ```
 
 ### `make testacc`

--- a/docs/resources/check.md
+++ b/docs/resources/check.md
@@ -68,6 +68,14 @@ resource "checkly_check" "example_check_2" {
     }
   }
 
+  retry_strategy {
+    type = "FIXED"
+    base_backoff_seconds = 60
+    max_duration_seconds = 600
+    max_attempts = 3
+    same_region = false
+  }
+
   request {
     follow_redirects = true
     skip_ssl         = false
@@ -208,6 +216,7 @@ resource "checkly_check" "example_check" {
 - `muted` (Boolean) Determines if any notifications will be sent out when a check fails/degrades/recovers.
 - `private_locations` (Set of String) An array of one or more private locations slugs.
 - `request` (Block Set, Max: 1) An API check might have one request config. (see [below for nested schema](#nestedblock--request))
+- `retry_strategy` (Block Set, Max: 1) (see [below for nested schema](#nestedblock--retry_strategy))
 - `runtime_id` (String) The id of the runtime to use for this check.
 - `script` (String) A valid piece of Node.js JavaScript code describing a browser interaction with the Puppeteer/Playwright framework or a reference to an external JavaScript file.
 - `setup_snippet_id` (Number) An ID reference to a snippet to use in the setup phase of an API check.
@@ -330,5 +339,21 @@ Required:
 
 - `password` (String)
 - `username` (String)
+
+
+
+<a id="nestedblock--retry_strategy"></a>
+### Nested Schema for `retry_strategy`
+
+Required:
+
+- `type` (String) Determines which type of retry strategy to use. Possible values are `FIXED`, `LINEAR`, or `EXPONENTIAL`.
+
+Optional:
+
+- `base_backoff_seconds` (Number) The number of seconds to wait before the first retry attempt.
+- `max_attempts` (Number) The maximum number of attempts to retry the check. Value must be between 1 and 10.
+- `max_duration_seconds` (Number) The total amount of time to continue retrying the check (maximum 600 seconds).
+- `same_region` (Boolean) Whether retries should be run in the same region as the initial check run.
 
 

--- a/docs/resources/check_group.md
+++ b/docs/resources/check_group.md
@@ -157,6 +157,7 @@ resource "checkly_check_group" "test_group1" {
 - `locations` (Set of String) An array of one or more data center locations where to run the checks.
 - `muted` (Boolean) Determines if any notifications will be sent out when a check in this group fails and/or recovers.
 - `private_locations` (Set of String) An array of one or more private locations slugs.
+- `retry_strategy` (Block Set, Max: 1) (see [below for nested schema](#nestedblock--retry_strategy))
 - `runtime_id` (String) The id of the runtime to use for this group.
 - `setup_snippet_id` (Number) An ID reference to a snippet to use in the setup phase of an API check.
 - `tags` (Set of String) Tags for organizing and filtering checks.
@@ -271,5 +272,20 @@ Required:
 Optional:
 
 - `locked` (Boolean)
+
+
+<a id="nestedblock--retry_strategy"></a>
+### Nested Schema for `retry_strategy`
+
+Required:
+
+- `type` (String) Determines which type of retry strategy to use. Possible values are `FIXED`, `LINEAR`, or `EXPONENTIAL`.
+
+Optional:
+
+- `base_backoff_seconds` (Number) The number of seconds to wait before the first retry attempt.
+- `max_attempts` (Number) The maximum number of attempts to retry the check. Value must be between 1 and 10.
+- `max_duration_seconds` (Number) The total amount of time to continue retrying the check (maximum 600 seconds).
+- `same_region` (Boolean) Whether retries should be run in the same region as the initial check run.
 
 

--- a/examples/resources/checkly_check/resource.tf
+++ b/examples/resources/checkly_check/resource.tf
@@ -53,6 +53,14 @@ resource "checkly_check" "example_check_2" {
     }
   }
 
+  retry_strategy {
+    type = "FIXED"
+    base_backoff_seconds = 60
+    max_duration_seconds = 600
+    max_attempts = 3
+    same_region = false
+  }
+
   request {
     follow_redirects = true
     skip_ssl         = false

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/aws/aws-sdk-go v1.44.122 // indirect
-	github.com/checkly/checkly-go-sdk v1.6.7
+	github.com/checkly/checkly-go-sdk v1.6.8
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/google/go-cmp v0.5.9
 	github.com/gruntwork-io/terratest v0.41.16

--- a/go.sum
+++ b/go.sum
@@ -233,6 +233,8 @@ github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghf
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/checkly/checkly-go-sdk v1.6.7 h1:OhTsFwFKZYV9LsYyV1SuoU0Ql113Zk1D+JBTt+uVm7c=
 github.com/checkly/checkly-go-sdk v1.6.7/go.mod h1:Pd6tBOggAe41NnCU5KwqA8JvD6J20/IctszT2E0AvHo=
+github.com/checkly/checkly-go-sdk v1.6.8 h1:7rQ+zrwlLYYOc0u5jxDT1+atLFnwWmaqJluDLJtrjW0=
+github.com/checkly/checkly-go-sdk v1.6.8/go.mod h1:Pd6tBOggAe41NnCU5KwqA8JvD6J20/IctszT2E0AvHo=
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=


### PR DESCRIPTION
## Affected Components
* [x] Resources
* [ ] Test
* [x] Docs
* [ ] Tooling
* [ ] Other

## Pre-Requisites
* [x] Terraform code is formatted with `terraform fmt`
* [x] Go code is formatted with `go fmt`
* [x] `plan` & `apply` command of `demo/main.tf` file do not produce diffs

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
This PR adds support for retry strategies to checks and check groups. This PR depends on a new release of the checkly-go-sdk with https://github.com/checkly/checkly-go-sdk/pull/113 (that's causing CI to fail currently).
