### PR TITLE
chore(docs): mark double_check as deprecated

### DIFF
--- a/checkly/resource_check.go
+++ b/checkly/resource_check.go
@@ -150,6 +150,7 @@ func resourceCheck() *schema.Resource {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Description: "Setting this to `true` will trigger a retry when a check fails from the failing region and another, randomly selected region before marking the check as failed.",
+				Deprecated: "The property `double_check` is deprecated and will be removed in a future version. To enable retries for failed check runs, use the `retry_strategy` property instead.",
 			},
 			"tags": {
 				Type:     schema.TypeSet,
@@ -458,6 +459,7 @@ func resourceCheck() *schema.Resource {
 				DefaultFunc: func() (interface{}, error) {
 					return []tfMap{}, nil
 				},
+				Description: "A strategy for retrying failed check runs.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"type": {

--- a/checkly/resource_check_group.go
+++ b/checkly/resource_check_group.go
@@ -94,6 +94,7 @@ func resourceCheckGroup() *schema.Resource {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Description: "Setting this to `true` will trigger a retry when a check fails from the failing region and another, randomly selected region before marking the check as failed.",
+				Deprecated: "The property `double_check` is deprecated and will be removed in a future version. To enable retries for failed check runs, use the `retry_strategy` property instead.",
 			},
 			"tags": {
 				Type:     schema.TypeSet,
@@ -339,6 +340,7 @@ func resourceCheckGroup() *schema.Resource {
 				DefaultFunc: func() (interface{}, error) {
 					return []tfMap{}, nil
 				},
+				Description: "A strategy for retrying failed check runs.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"type": {

--- a/docs/resources/check.md
+++ b/docs/resources/check.md
@@ -203,7 +203,7 @@ resource "checkly_check" "example_check" {
 - `alert_channel_subscription` (Block List) (see [below for nested schema](#nestedblock--alert_channel_subscription))
 - `alert_settings` (Block Set, Max: 1) (see [below for nested schema](#nestedblock--alert_settings))
 - `degraded_response_time` (Number) The response time in milliseconds starting from which a check should be considered degraded. Possible values are between 0 and 30000. (Default `15000`).
-- `double_check` (Boolean) Setting this to `true` will trigger a retry when a check fails from the failing region and another, randomly selected region before marking the check as failed.
+- `double_check` (Boolean, Deprecated) Setting this to `true` will trigger a retry when a check fails from the failing region and another, randomly selected region before marking the check as failed.
 - `environment_variable` (Block List) Key/value pairs for setting environment variables during check execution, add locked = true to keep value hidden. These are only relevant for browser checks. Use global environment variables whenever possible. (see [below for nested schema](#nestedblock--environment_variable))
 - `environment_variables` (Map of String, Deprecated) Key/value pairs for setting environment variables during check execution. These are only relevant for browser checks. Use global environment variables whenever possible.
 - `frequency_offset` (Number) This property only valid for API high frequency checks. To create a hight frequency check, the property `frequency` must be `0` and `frequency_offset` could be `10`, `20` or `30`.
@@ -216,7 +216,7 @@ resource "checkly_check" "example_check" {
 - `muted` (Boolean) Determines if any notifications will be sent out when a check fails/degrades/recovers.
 - `private_locations` (Set of String) An array of one or more private locations slugs.
 - `request` (Block Set, Max: 1) An API check might have one request config. (see [below for nested schema](#nestedblock--request))
-- `retry_strategy` (Block Set, Max: 1) (see [below for nested schema](#nestedblock--retry_strategy))
+- `retry_strategy` (Block Set, Max: 1) A strategy for retrying failed check runs. (see [below for nested schema](#nestedblock--retry_strategy))
 - `runtime_id` (String) The id of the runtime to use for this check.
 - `script` (String) A valid piece of Node.js JavaScript code describing a browser interaction with the Puppeteer/Playwright framework or a reference to an external JavaScript file.
 - `setup_snippet_id` (Number) An ID reference to a snippet to use in the setup phase of an API check.

--- a/docs/resources/check_group.md
+++ b/docs/resources/check_group.md
@@ -149,7 +149,7 @@ resource "checkly_check_group" "test_group1" {
 - `alert_channel_subscription` (Block List) (see [below for nested schema](#nestedblock--alert_channel_subscription))
 - `alert_settings` (Block Set, Max: 1) (see [below for nested schema](#nestedblock--alert_settings))
 - `api_check_defaults` (Block Set, Max: 1) (see [below for nested schema](#nestedblock--api_check_defaults))
-- `double_check` (Boolean) Setting this to `true` will trigger a retry when a check fails from the failing region and another, randomly selected region before marking the check as failed.
+- `double_check` (Boolean, Deprecated) Setting this to `true` will trigger a retry when a check fails from the failing region and another, randomly selected region before marking the check as failed.
 - `environment_variable` (Block List) Key/value pairs for setting environment variables during check execution, add locked = true to keep value hidden. These are only relevant for browser checks. Use global environment variables whenever possible. (see [below for nested schema](#nestedblock--environment_variable))
 - `environment_variables` (Map of String, Deprecated) Key/value pairs for setting environment variables during check execution. These are only relevant for browser checks. Use global environment variables whenever possible.
 - `local_setup_script` (String) A valid piece of Node.js code to run in the setup phase of an API check in this group.
@@ -157,7 +157,7 @@ resource "checkly_check_group" "test_group1" {
 - `locations` (Set of String) An array of one or more data center locations where to run the checks.
 - `muted` (Boolean) Determines if any notifications will be sent out when a check in this group fails and/or recovers.
 - `private_locations` (Set of String) An array of one or more private locations slugs.
-- `retry_strategy` (Block Set, Max: 1) (see [below for nested schema](#nestedblock--retry_strategy))
+- `retry_strategy` (Block Set, Max: 1) A strategy for retrying failed check runs. (see [below for nested schema](#nestedblock--retry_strategy))
 - `runtime_id` (String) The id of the runtime to use for this group.
 - `setup_snippet_id` (Number) An ID reference to a snippet to use in the setup phase of an API check.
 - `tags` (Set of String) Tags for organizing and filtering checks.


### PR DESCRIPTION
## Affected Components
* [ ] Resources
* [ ] Test
* [x] Docs
* [ ] Tooling
* [ ] Other

## Pre-Requisites
* [ ] Terraform code is formatted with `terraform fmt`
* [ ] Go code is formatted with `go fmt`
* [ ] `plan` & `apply` command of `demo/main.tf` file do not produce diffs

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
This PR updates the documentation to mark the `double_check` property as deprecated. It also adds additional documentation for `retry_strategy`.


![Screenshot 2023-08-31 at 12 10 19](https://github.com/checkly/terraform-provider-checkly/assets/10483186/19fc2af7-8b47-4808-be4a-cee6969a54de)

