### PR TITLE
feat: rename retry strategy max_attempts to max_retries

### DIFF
--- a/checkly/resource_check.go
+++ b/checkly/resource_check.go
@@ -473,11 +473,11 @@ func resourceCheck() *schema.Resource {
 							Default:     60,
 							Description: "The number of seconds to wait before the first retry attempt.",
 						},
-						"max_attempts": {
+						"max_retries": {
 							Type:        schema.TypeInt,
 							Optional:    true,
 							Default:     2,
-							Description: "The maximum number of attempts to retry the check. Value must be between 1 and 10.",
+							Description: "The maximum number of times to retry the check. Value must be between 1 and 10.",
 						},
 						"max_duration_seconds": {
 							Type:        schema.TypeInt,
@@ -719,7 +719,7 @@ func setFromRetryStrategy(rs *checkly.RetryStrategy) []tfMap {
 		{
 			"type":                 rs.Type,
 			"base_backoff_seconds": rs.BaseBackoffSeconds,
-			"max_attempts":         rs.MaxAttempts,
+			"max_retries":          rs.MaxRetries,
 			"max_duration_seconds": rs.MaxDurationSeconds,
 			"same_region":          rs.SameRegion,
 		},
@@ -857,7 +857,7 @@ func retryStrategyFromSet(s *schema.Set) *checkly.RetryStrategy {
 	return &checkly.RetryStrategy{
 		Type:               res["type"].(string),
 		BaseBackoffSeconds: res["base_backoff_seconds"].(int),
-		MaxAttempts:        res["max_attempts"].(int),
+		MaxRetries:         res["max_retries"].(int),
 		MaxDurationSeconds: res["max_duration_seconds"].(int),
 		SameRegion:         res["same_region"].(bool),
 	}

--- a/checkly/resource_check_group.go
+++ b/checkly/resource_check_group.go
@@ -354,11 +354,11 @@ func resourceCheckGroup() *schema.Resource {
 							Default:     60,
 							Description: "The number of seconds to wait before the first retry attempt.",
 						},
-						"max_attempts": {
+						"max_retries": {
 							Type:        schema.TypeInt,
 							Optional:    true,
 							Default:     2,
-							Description: "The maximum number of attempts to retry the check. Value must be between 1 and 10.",
+							Description: "The maximum number of times to retry the check. Value must be between 1 and 10.",
 						},
 						"max_duration_seconds": {
 							Type:        schema.TypeInt,

--- a/docs/resources/check.md
+++ b/docs/resources/check.md
@@ -72,7 +72,7 @@ resource "checkly_check" "example_check_2" {
     type = "FIXED"
     base_backoff_seconds = 60
     max_duration_seconds = 600
-    max_attempts = 3
+    max_retries = 3
     same_region = false
   }
 
@@ -352,8 +352,8 @@ Required:
 Optional:
 
 - `base_backoff_seconds` (Number) The number of seconds to wait before the first retry attempt.
-- `max_attempts` (Number) The maximum number of attempts to retry the check. Value must be between 1 and 10.
 - `max_duration_seconds` (Number) The total amount of time to continue retrying the check (maximum 600 seconds).
+- `max_retries` (Number) The maximum number of times to retry the check. Value must be between 1 and 10.
 - `same_region` (Boolean) Whether retries should be run in the same region as the initial check run.
 
 

--- a/docs/resources/check_group.md
+++ b/docs/resources/check_group.md
@@ -284,8 +284,8 @@ Required:
 Optional:
 
 - `base_backoff_seconds` (Number) The number of seconds to wait before the first retry attempt.
-- `max_attempts` (Number) The maximum number of attempts to retry the check. Value must be between 1 and 10.
 - `max_duration_seconds` (Number) The total amount of time to continue retrying the check (maximum 600 seconds).
+- `max_retries` (Number) The maximum number of times to retry the check. Value must be between 1 and 10.
 - `same_region` (Boolean) Whether retries should be run in the same region as the initial check run.
 
 

--- a/examples/resources/checkly_check/resource.tf
+++ b/examples/resources/checkly_check/resource.tf
@@ -57,7 +57,7 @@ resource "checkly_check" "example_check_2" {
     type = "FIXED"
     base_backoff_seconds = 60
     max_duration_seconds = 600
-    max_attempts = 3
+    max_retries = 3
     same_region = false
   }
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/aws/aws-sdk-go v1.44.122 // indirect
-	github.com/checkly/checkly-go-sdk v1.6.8
+	github.com/checkly/checkly-go-sdk v1.6.9
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/google/go-cmp v0.5.9
 	github.com/gruntwork-io/terratest v0.41.16

--- a/go.sum
+++ b/go.sum
@@ -235,6 +235,8 @@ github.com/checkly/checkly-go-sdk v1.6.7 h1:OhTsFwFKZYV9LsYyV1SuoU0Ql113Zk1D+JBT
 github.com/checkly/checkly-go-sdk v1.6.7/go.mod h1:Pd6tBOggAe41NnCU5KwqA8JvD6J20/IctszT2E0AvHo=
 github.com/checkly/checkly-go-sdk v1.6.8 h1:7rQ+zrwlLYYOc0u5jxDT1+atLFnwWmaqJluDLJtrjW0=
 github.com/checkly/checkly-go-sdk v1.6.8/go.mod h1:Pd6tBOggAe41NnCU5KwqA8JvD6J20/IctszT2E0AvHo=
+github.com/checkly/checkly-go-sdk v1.6.9 h1:2Cfr2I0VnHmB4oL7BOw25WYuyz5Lm04N50k1HUsX2Lk=
+github.com/checkly/checkly-go-sdk v1.6.9/go.mod h1:Pd6tBOggAe41NnCU5KwqA8JvD6J20/IctszT2E0AvHo=
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=


### PR DESCRIPTION
## Affected Components
* [x] Resources
* [ ] Test
* [x] Docs
* [ ] Tooling
* [ ] Other

## Pre-Requisites
* [x] Terraform code is formatted with `terraform fmt`
* [x] Go code is formatted with `go fmt`
* [x] `plan` & `apply` command of `demo/main.tf` file do not produce diffs

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
We recently added support for retry strategies in https://github.com/checkly/terraform-provider-checkly/pull/271. This PR updates the `max_attempts` field to the more accurate name `max_retries`.