### PR TITLE
docs: remove double_check and use correct provider version

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -37,7 +37,7 @@ terraform {
   required_providers {
     checkly = {
       source = "checkly/checkly"
-      version = "1.6.10"
+      version = "1.7.1"
     }
   }
 }
@@ -55,7 +55,6 @@ resource "checkly_check" "example_check" {
   activated                 = true
   should_fail               = false
   frequency                 = 10
-  double_check              = true
   use_global_alert_settings = true
 
   locations = [

--- a/docs/resources/check.md
+++ b/docs/resources/check.md
@@ -20,7 +20,6 @@ resource "checkly_check" "example_check" {
   activated                 = true
   should_fail               = false
   frequency                 = 1
-  double_check              = true
   use_global_alert_settings = true
 
   locations = [
@@ -46,7 +45,6 @@ resource "checkly_check" "example_check_2" {
   activated              = true
   should_fail            = true
   frequency              = 1
-  double_check           = true
   degraded_response_time = 5000
   max_response_time      = 10000
 
@@ -117,7 +115,6 @@ resource "checkly_check" "browser_check_1" {
   activated                 = true
   should_fail               = false
   frequency                 = 10
-  double_check              = true
   use_global_alert_settings = true
   locations = [
     "us-west-1"
@@ -177,7 +174,6 @@ resource "checkly_check" "example_check" {
 #   activated                 = true
 #   should_fail               = false
 #   frequency                 = 10
-#   double_check              = true
 #   use_global_alert_settings = true
 #   locations = [
 #     "us-west-1"

--- a/docs/resources/check_group.md
+++ b/docs/resources/check_group.md
@@ -67,7 +67,6 @@ resource "checkly_check_group" "test_group1" {
     locked = true
   }
 
-  double_check              = true
   use_global_alert_settings = false
 
   alert_settings {

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     checkly = {
       source = "checkly/checkly"
-      version = "1.6.10"
+      version = "1.7.1"
     }
   }
 }
@@ -25,7 +25,6 @@ resource "checkly_check" "example_check" {
   activated                 = true
   should_fail               = false
   frequency                 = 10
-  double_check              = true
   use_global_alert_settings = true
 
   locations = [

--- a/examples/resources/checkly_check/resource.tf
+++ b/examples/resources/checkly_check/resource.tf
@@ -5,7 +5,6 @@ resource "checkly_check" "example_check" {
   activated                 = true
   should_fail               = false
   frequency                 = 1
-  double_check              = true
   use_global_alert_settings = true
 
   locations = [
@@ -31,7 +30,6 @@ resource "checkly_check" "example_check_2" {
   activated              = true
   should_fail            = true
   frequency              = 1
-  double_check           = true
   degraded_response_time = 5000
   max_response_time      = 10000
 
@@ -102,7 +100,6 @@ resource "checkly_check" "browser_check_1" {
   activated                 = true
   should_fail               = false
   frequency                 = 10
-  double_check              = true
   use_global_alert_settings = true
   locations = [
     "us-west-1"
@@ -162,7 +159,6 @@ resource "checkly_check" "example_check" {
 #   activated                 = true
 #   should_fail               = false
 #   frequency                 = 10
-#   double_check              = true
 #   use_global_alert_settings = true
 #   locations = [
 #     "us-west-1"

--- a/examples/resources/checkly_check_group/resource.tf
+++ b/examples/resources/checkly_check_group/resource.tf
@@ -52,7 +52,6 @@ resource "checkly_check_group" "test_group1" {
     locked = true
   }
 
-  double_check              = true
   use_global_alert_settings = false
 
   alert_settings {


### PR DESCRIPTION
## Affected Components
* [ ] Resources
* [ ] Tests
* [x] Docs
* [ ] Other

## Style
* [ ] Terraform code is formatted with `terraform fmt`
* [ ] Go code is formatted with `go fmt`

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
This PR adds some fixes in the examples that slipped through earlier.

* `double_check` has been deprecated so we should remove it from the examples
* The examples reference Checkly provider version 1.6.10. We actually ended up bumping the minor version, though, so it should be 1.7.1.