### PR TITLE
Antoinecoutellier/sc 17816/add multistep checks to terraform

### DIFF
--- a/checkly/resource_check.go
+++ b/checkly/resource_check.go
@@ -533,7 +533,7 @@ func resourceCheckCreate(d *schema.ResourceData, client interface{}) error {
 func resourceCheckRead(d *schema.ResourceData, client interface{}) error {
 	ctx, cancel := context.WithTimeout(context.Background(), apiCallTimeout())
 	defer cancel()
-	check, err := client.(checkly.Client).Get(ctx, d.Id())
+	check, err := client.(checkly.Client).GetCheck(ctx, d.Id())
 	if err != nil {
 		if strings.Contains(err.Error(), "404") {
 			//if resource is deleted remotely, then mark it as
@@ -554,7 +554,7 @@ func resourceCheckUpdate(d *schema.ResourceData, client interface{}) error {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), apiCallTimeout())
 	defer cancel()
-	_, err = client.(checkly.Client).Update(ctx, check.ID, check)
+	_, err = client.(checkly.Client).UpdateCheck(ctx, check.ID, check)
 	if err != nil {
 		checkJSON, _ := json.Marshal(check)
 		return fmt.Errorf("API error 3: Couldn't update check, Error: %w, \nCheck: %s", err, checkJSON)
@@ -566,7 +566,7 @@ func resourceCheckUpdate(d *schema.ResourceData, client interface{}) error {
 func resourceCheckDelete(d *schema.ResourceData, client interface{}) error {
 	ctx, cancel := context.WithTimeout(context.Background(), apiCallTimeout())
 	defer cancel()
-	if err := client.(checkly.Client).Delete(ctx, d.Id()); err != nil {
+	if err := client.(checkly.Client).DeleteCheck(ctx, d.Id()); err != nil {
 		return fmt.Errorf("API error 4: Couldn't delete Check %s, Error: %w", d.Id(), err)
 	}
 	return nil

--- a/checkly/resource_check_test.go
+++ b/checkly/resource_check_test.go
@@ -212,6 +212,75 @@ func TestAccApiCheckBasic(t *testing.T) {
 	})
 }
 
+func TestAccMultiStepCheckBasic(t *testing.T) {
+	accTestCase(t, []resource.TestStep{
+		{
+			Config: multiStepCheck_basic,
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr(
+					"checkly_check.test",
+					"name",
+					"MultiStep Check",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_check.test",
+					"type",
+					"MULTI_STEP",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_check.test",
+					"runtime_id",
+					"2023.09",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_check.test",
+					"activated",
+					"true",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_check.test",
+					"script",
+					"console.log('test')",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_check.test",
+					"locations.#",
+					"2",
+				),
+				testCheckResourceAttrExpr(
+					"checkly_check.test",
+					"locations.*",
+					"us-east-1",
+				),
+				testCheckResourceAttrExpr(
+					"checkly_check.test",
+					"locations.*",
+					"eu-central-1",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_check.test",
+					"tags.#",
+					"2",
+				),
+				testCheckResourceAttrExpr(
+					"checkly_check.test",
+					"tags.*",
+					"browser",
+				),
+				testCheckResourceAttrExpr(
+					"checkly_check.test",
+					"tags.*",
+					"e2e",
+				),
+				resource.TestCheckNoResourceAttr(
+					"checkly_check.test",
+					"request",
+				),
+			),
+		},
+	})
+}
+
 func TestAccApiCheckFull(t *testing.T) {
 	accTestCase(t, []resource.TestStep{
 		{
@@ -431,6 +500,22 @@ const browserCheck_basic = `
 		script                    = "console.log('test')"
 	}
 `
+const multiStepCheck_basic = `
+	resource "checkly_check" "test" {
+		name                      = "MultiStep Check"
+		type                      = "MULTI_STEP"
+		activated                 = true
+		should_fail               = false
+		frequency                 = 720
+		double_check              = true
+		use_global_alert_settings = true
+		locations                 = [ "us-east-1", "eu-central-1" ]
+		tags                      = [ "browser", "e2e" ]
+		runtime_id				  = "2023.09"
+		script                    = "console.log('test')"
+	}
+`
+
 const apiCheck_basic = `
 	resource "checkly_check" "test" {
 	  name                      = "API Check 1"

--- a/checkly/resource_check_test.go
+++ b/checkly/resource_check_test.go
@@ -510,7 +510,7 @@ const multiStepCheck_basic = `
 		double_check              = true
 		use_global_alert_settings = true
 		locations                 = [ "us-east-1", "eu-central-1" ]
-		tags                      = [ "browser", "e2e" ]
+		tags                      = [ "api", "multi-step" ]
 		runtime_id				  = "2023.09"
 		script                    = "console.log('test')"
 	}

--- a/docs/resources/check.md
+++ b/docs/resources/check.md
@@ -192,7 +192,7 @@ resource "checkly_check" "example_check" {
 - `activated` (Boolean) Determines if the check is running or not. Possible values `true`, and `false`.
 - `frequency` (Number) The frequency in minutes to run the check. Possible values are `0`, `1`, `2`, `5`, `10`, `15`, `30`, `60`, `120`, `180`, `360`, `720`, and `1440`.
 - `name` (String) The name of the check.
-- `type` (String) The type of the check. Possible values are `API`, and `BROWSER`.
+- `type` (String) The type of the check. Possible values are `API`, `BROWSER`, and `MULTI_STEP`.
 
 ### Optional
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/aws/aws-sdk-go v1.44.122 // indirect
-	github.com/checkly/checkly-go-sdk v1.6.9
+	github.com/checkly/checkly-go-sdk v1.7.0
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/google/go-cmp v0.5.9
 	github.com/gruntwork-io/terratest v0.41.16

--- a/go.sum
+++ b/go.sum
@@ -237,6 +237,8 @@ github.com/checkly/checkly-go-sdk v1.6.8 h1:7rQ+zrwlLYYOc0u5jxDT1+atLFnwWmaqJluD
 github.com/checkly/checkly-go-sdk v1.6.8/go.mod h1:Pd6tBOggAe41NnCU5KwqA8JvD6J20/IctszT2E0AvHo=
 github.com/checkly/checkly-go-sdk v1.6.9 h1:2Cfr2I0VnHmB4oL7BOw25WYuyz5Lm04N50k1HUsX2Lk=
 github.com/checkly/checkly-go-sdk v1.6.9/go.mod h1:Pd6tBOggAe41NnCU5KwqA8JvD6J20/IctszT2E0AvHo=
+github.com/checkly/checkly-go-sdk v1.7.0 h1:3BXWIE1YjXfWTwuhZ5bE6QkcfJbchFE/Y/pPaQtT0+c=
+github.com/checkly/checkly-go-sdk v1.7.0/go.mod h1:Pd6tBOggAe41NnCU5KwqA8JvD6J20/IctszT2E0AvHo=
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=


### PR DESCRIPTION
## Affected Components
* [x] Resources
* [ ] Test
* [ ] Docs
* [ ] Tooling
* [ ] Other

## Pre-Requisites
* [x] Terraform code is formatted with `terraform fmt`
* [x] Go code is formatted with `go fmt`
* [x] `plan` & `apply` command of `demo/main.tf` file do not produce diffs

## Notes for the Reviewer

- Add support for MULTI_STEP checks.

This PR needs https://github.com/checkly/checkly-go-sdk/pull/117 to be merged first.