### PR TITLE
feat(parallel): add `runParallel` to TF check and group constructs [sc-18211]

### DIFF
--- a/checkly/resource_check.go
+++ b/checkly/resource_check.go
@@ -76,6 +76,11 @@ func resourceCheck() *schema.Resource {
 				Optional:    true,
 				Description: "Allows to invert the behaviour of when a check is considered to fail. Allows for validating error status like 404.",
 			},
+			"run_parallel": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Determines if the check should run in all selected locations in parallel or round-robin.",
+			},
 			"locations": {
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -578,6 +583,7 @@ func resourceDataFromCheck(c *checkly.Check, d *schema.ResourceData) error {
 	d.Set("activated", c.Activated)
 	d.Set("muted", c.Muted)
 	d.Set("should_fail", c.ShouldFail)
+	d.Set("run_parallel", c.RunParallel)
 	d.Set("locations", c.Locations)
 	d.Set("script", c.Script)
 	d.Set("degraded_response_time", c.DegradedResponseTime)
@@ -750,6 +756,7 @@ func checkFromResourceData(d *schema.ResourceData) (checkly.Check, error) {
 		Activated:                 d.Get("activated").(bool),
 		Muted:                     d.Get("muted").(bool),
 		ShouldFail:                d.Get("should_fail").(bool),
+		RunParallel:               d.Get("run_parallel").(bool),
 		Locations:                 stringsFromSet(d.Get("locations").(*schema.Set)),
 		Script:                    d.Get("script").(string),
 		DegradedResponseTime:      d.Get("degraded_response_time").(int),

--- a/checkly/resource_check_group.go
+++ b/checkly/resource_check_group.go
@@ -43,6 +43,11 @@ func resourceCheckGroup() *schema.Resource {
 				Optional:    true,
 				Description: "Determines if any notifications will be sent out when a check in this group fails and/or recovers.",
 			},
+			"run_parallel": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Determines if the checks in the group should run in all selected locations in parallel or round-robin.",
+			},
 			"locations": {
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -447,6 +452,7 @@ func resourceDataFromCheckGroup(g *checkly.Group, d *schema.ResourceData) error 
 	d.Set("concurrency", g.Concurrency)
 	d.Set("activated", g.Activated)
 	d.Set("muted", g.Muted)
+	d.Set("run_parallel", g.RunParallel)
 	d.Set("locations", g.Locations)
 	d.Set("double_check", g.DoubleCheck)
 	d.Set("setup_snippet_id", g.SetupSnippetID)
@@ -500,6 +506,7 @@ func checkGroupFromResourceData(d *schema.ResourceData) (checkly.Group, error) {
 		Concurrency:               d.Get("concurrency").(int),
 		Activated:                 d.Get("activated").(bool),
 		Muted:                     d.Get("muted").(bool),
+		RunParallel:               d.Get("run_parallel").(bool),
 		Locations:                 stringsFromSet(d.Get("locations").(*schema.Set)),
 		DoubleCheck:               d.Get("double_check").(bool),
 		Tags:                      stringsFromSet(d.Get("tags").(*schema.Set)),

--- a/docs/resources/check.md
+++ b/docs/resources/check.md
@@ -213,6 +213,7 @@ resource "checkly_check" "example_check" {
 - `private_locations` (Set of String) An array of one or more private locations slugs.
 - `request` (Block Set, Max: 1) An API check might have one request config. (see [below for nested schema](#nestedblock--request))
 - `retry_strategy` (Block Set, Max: 1) A strategy for retrying failed check runs. (see [below for nested schema](#nestedblock--retry_strategy))
+- `run_parallel` (Boolean) Determines if the check should run in all selected locations in parallel or round-robin.
 - `runtime_id` (String) The id of the runtime to use for this check.
 - `script` (String) A valid piece of Node.js JavaScript code describing a browser interaction with the Puppeteer/Playwright framework or a reference to an external JavaScript file.
 - `setup_snippet_id` (Number) An ID reference to a snippet to use in the setup phase of an API check.

--- a/docs/resources/check_group.md
+++ b/docs/resources/check_group.md
@@ -157,6 +157,7 @@ resource "checkly_check_group" "test_group1" {
 - `muted` (Boolean) Determines if any notifications will be sent out when a check in this group fails and/or recovers.
 - `private_locations` (Set of String) An array of one or more private locations slugs.
 - `retry_strategy` (Block Set, Max: 1) A strategy for retrying failed check runs. (see [below for nested schema](#nestedblock--retry_strategy))
+- `run_parallel` (Boolean) Determines if the checks in the group should run in all selected locations in parallel or round-robin.
 - `runtime_id` (String) The id of the runtime to use for this group.
 - `setup_snippet_id` (Number) An ID reference to a snippet to use in the setup phase of an API check.
 - `tags` (Set of String) Tags for organizing and filtering checks.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/aws/aws-sdk-go v1.44.122 // indirect
-	github.com/checkly/checkly-go-sdk v1.7.0
+	github.com/checkly/checkly-go-sdk v1.7.1
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/google/go-cmp v0.5.9
 	github.com/gruntwork-io/terratest v0.41.16

--- a/go.mod
+++ b/go.mod
@@ -97,5 +97,3 @@ require (
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-replace github.com/checkly/checkly-go-sdk => ../checkly-go-sdk

--- a/go.mod
+++ b/go.mod
@@ -97,3 +97,5 @@ require (
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/checkly/checkly-go-sdk => ../checkly-go-sdk

--- a/go.sum
+++ b/go.sum
@@ -231,14 +231,8 @@ github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kB
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/checkly/checkly-go-sdk v1.6.7 h1:OhTsFwFKZYV9LsYyV1SuoU0Ql113Zk1D+JBTt+uVm7c=
-github.com/checkly/checkly-go-sdk v1.6.7/go.mod h1:Pd6tBOggAe41NnCU5KwqA8JvD6J20/IctszT2E0AvHo=
-github.com/checkly/checkly-go-sdk v1.6.8 h1:7rQ+zrwlLYYOc0u5jxDT1+atLFnwWmaqJluDLJtrjW0=
-github.com/checkly/checkly-go-sdk v1.6.8/go.mod h1:Pd6tBOggAe41NnCU5KwqA8JvD6J20/IctszT2E0AvHo=
-github.com/checkly/checkly-go-sdk v1.6.9 h1:2Cfr2I0VnHmB4oL7BOw25WYuyz5Lm04N50k1HUsX2Lk=
-github.com/checkly/checkly-go-sdk v1.6.9/go.mod h1:Pd6tBOggAe41NnCU5KwqA8JvD6J20/IctszT2E0AvHo=
-github.com/checkly/checkly-go-sdk v1.7.0 h1:3BXWIE1YjXfWTwuhZ5bE6QkcfJbchFE/Y/pPaQtT0+c=
-github.com/checkly/checkly-go-sdk v1.7.0/go.mod h1:Pd6tBOggAe41NnCU5KwqA8JvD6J20/IctszT2E0AvHo=
+github.com/checkly/checkly-go-sdk v1.7.1 h1:6pIu821nf2OjzdaZ8hfNGKcIMaVLzaU7JWDJlk66XGM=
+github.com/checkly/checkly-go-sdk v1.7.1/go.mod h1:Pd6tBOggAe41NnCU5KwqA8JvD6J20/IctszT2E0AvHo=
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=


### PR DESCRIPTION
## Affected Components
* [x] Resources
* [ ] Test
* [ ] Docs
* [ ] Tooling
* [ ] Other

## Pre-Requisites
* [x] Terraform code is formatted with `terraform fmt`
* [x] Go code is formatted with `go fmt`
* [ ] `plan` & `apply` command of `demo/main.tf` file do not produce diffs

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->
Add `runParallel` to check and group constructs to allow simultaneous check run scheduling on multi-locations.

If set to false, the check run will be scheduled in the different locations in a round-robin fashion.
