### PR TITLE
chore: add description for alert channel subscriptions

### DIFF
--- a/checkly/resource_check.go
+++ b/checkly/resource_check.go
@@ -205,7 +205,7 @@ func resourceCheck() *schema.Resource {
 			"alert_channel_subscription": {
 				Type:        schema.TypeList,
 				Optional:    true,
-				Description: "An array of channel ID and if it's activated or not. If you don't set at least one alert subscription for your check, we won't be able to alert you in case something goes wrong with it.",
+				Description: "An array of channel IDs and whether they're activated or not. If you don't set at least one alert subscription for your check, we won't be able to alert you in case something goes wrong with it.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"channel_id": {

--- a/checkly/resource_check.go
+++ b/checkly/resource_check.go
@@ -150,7 +150,7 @@ func resourceCheck() *schema.Resource {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Description: "Setting this to `true` will trigger a retry when a check fails from the failing region and another, randomly selected region before marking the check as failed.",
-				Deprecated: "The property `double_check` is deprecated and will be removed in a future version. To enable retries for failed check runs, use the `retry_strategy` property instead.",
+				Deprecated:  "The property `double_check` is deprecated and will be removed in a future version. To enable retries for failed check runs, use the `retry_strategy` property instead.",
 			},
 			"tags": {
 				Type:     schema.TypeSet,
@@ -198,8 +198,9 @@ func resourceCheck() *schema.Resource {
 				Description: "The id of the runtime to use for this check.",
 			},
 			"alert_channel_subscription": {
-				Type:     schema.TypeList,
-				Optional: true,
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: "An array of channel ID and if it's activated or not. If you don't set at least one alert subscription for your check, we won't be able to alert you in case something goes wrong with it.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"channel_id": {

--- a/docs/resources/check.md
+++ b/docs/resources/check.md
@@ -196,7 +196,7 @@ resource "checkly_check" "example_check" {
 
 ### Optional
 
-- `alert_channel_subscription` (Block List) An array of channel ID and if it's activated or not. If you don't set at least one alert subscription for your check, we won't be able to alert you in case something goes wrong with it. (see [below for nested schema](#nestedblock--alert_channel_subscription))
+- `alert_channel_subscription` (Block List) An array of channel IDs and whether they're activated or not. If you don't set at least one alert subscription for your check, we won't be able to alert you in case something goes wrong with it. (see [below for nested schema](#nestedblock--alert_channel_subscription))
 - `alert_settings` (Block Set, Max: 1) (see [below for nested schema](#nestedblock--alert_settings))
 - `degraded_response_time` (Number) The response time in milliseconds starting from which a check should be considered degraded. Possible values are between 0 and 30000. (Default `15000`).
 - `double_check` (Boolean, Deprecated) Setting this to `true` will trigger a retry when a check fails from the failing region and another, randomly selected region before marking the check as failed.

--- a/docs/resources/check.md
+++ b/docs/resources/check.md
@@ -196,7 +196,7 @@ resource "checkly_check" "example_check" {
 
 ### Optional
 
-- `alert_channel_subscription` (Block List) (see [below for nested schema](#nestedblock--alert_channel_subscription))
+- `alert_channel_subscription` (Block List) An array of channel ID and if it's activated or not. If you don't set at least one alert subscription for your check, we won't be able to alert you in case something goes wrong with it. (see [below for nested schema](#nestedblock--alert_channel_subscription))
 - `alert_settings` (Block Set, Max: 1) (see [below for nested schema](#nestedblock--alert_settings))
 - `degraded_response_time` (Number) The response time in milliseconds starting from which a check should be considered degraded. Possible values are between 0 and 30000. (Default `15000`).
 - `double_check` (Boolean, Deprecated) Setting this to `true` will trigger a retry when a check fails from the failing region and another, randomly selected region before marking the check as failed.


### PR DESCRIPTION
## Affected Components
* [x] Resources
* [ ] Test
* [ ] Docs
* [ ] Tooling
* [ ] Other

## Pre-Requisites
* [x] Terraform code is formatted with `terraform fmt`
* [x] Go code is formatted with `go fmt`
* [x] `plan` & `apply` command of `demo/main.tf` file do not produce diffs

## Notes for the Reviewer

- Add a better explanation in case the alert subscription array is empty or not set.