### PR TITLE
fix: remove permadiff on `ssl_check_domain`

### DIFF
--- a/checkly/resource_check.go
+++ b/checkly/resource_check.go
@@ -629,7 +629,7 @@ func resourceDataFromCheck(c *checkly.Check, d *schema.ResourceData) error {
 
 	// ssl_check_domain is only supported for Browser checks
 	if c.Type == "BROWSER" && c.SSLCheckDomain != "" {
-		d.Set("ssl_check_domain", c.Type)
+		d.Set("ssl_check_domain", c.SSLCheckDomain)
 	}
 
 	environmentVariables := environmentVariablesFromSet(d.Get("environment_variable").([]interface{}))


### PR DESCRIPTION
## Affected Components
* [x] Resources
* [ ] Test
* [ ] Docs
* [ ] Tooling
* [ ] Other

## Pre-Requisites
* [x] Terraform code is formatted with `terraform fmt`
* [x] Go code is formatted with `go fmt`
* [x] `plan` & `apply` command of `demo/main.tf` file do not produce diffs

## Notes for the Reviewer

> Resolves #282
