### PR TITLE
fix: improve multi-step runtime validation [sc-19433]

### DIFF
--- a/checkly/resource_check_test.go
+++ b/checkly/resource_check_test.go
@@ -212,6 +212,39 @@ func TestAccApiCheckBasic(t *testing.T) {
 	})
 }
 
+func TestAccMultiStepCheckRuntimeValidation(t *testing.T) {
+	unsupportedRuntime := `resource "checkly_check" "test" {
+		name = "test"
+		type = "MULTI_STEP"
+		activated = true
+		frequency = 5
+		locations = ["eu-central-1"]
+		script = "console.log('test')"
+		runtime_id = "2023.02"
+	}`
+	noSpecifiedRuntime := `resource "checkly_check" "test" {
+		name = "test"
+		type = "MULTI_STEP"
+		activated = true
+		frequency = 5
+		locations = ["eu-central-1"]
+		script = "console.log('test')"
+	}`
+	accTestCase(t, []resource.TestStep{
+		{
+			Config:      unsupportedRuntime,
+			ExpectError: regexp.MustCompile("Error: runtime 2023.02 does not support MULTI_STEP checks"),
+		},
+		{
+			Config: noSpecifiedRuntime,
+			Check: resource.TestCheckNoResourceAttr(
+				"checkly_check.test",
+				"runtime_id",
+			),
+		},
+	})
+}
+
 func TestAccMultiStepCheckBasic(t *testing.T) {
 	accTestCase(t, []resource.TestStep{
 		{


### PR DESCRIPTION
## Affected Components
* [ ] Resources
* [ ] Test
* [ ] Docs
* [ ] Tooling
* [ ] Other

## Pre-Requisites
* [ ] Terraform code is formatted with `terraform fmt`
* [ ] Go code is formatted with `go fmt`
* [ ] `plan` & `apply` command of `demo/main.tf` file do not produce diffs

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->
Resolves https://github.com/checkly/terraform-provider-checkly/issues/287

The Checkly TF Provider currently has validation to check that multi-step checks only use supported runtimes. This validation has a null-pointer-exception, though, since the `runtime_id` is an optional setting. To fix the error, this PR only validates the runtime ID if one is set. 

Before, the validation was only performed when creating a resource. This PR also performs the validation for updating a resource, since someone might change the runtime ID.

Currently the validation just checks that runtime ID set for the check, and ignores any that might be set on a group. Since a runtime ID set at the check level overrides any runtime ID set at the group level, this should work fine for the edge case where one runtime ID is set on the check and another is set on the group.

If no runtime ID is set on the check, then no validation is performed. To add validation in that case, we would need to add code to check the group's runtime ID and the account's default runtime ID. I think that we can skip that for now. 