### PR TITLE
Umutuzgur/tackle computed alert settings fields

### DIFF
--- a/checkly/resource_check_group.go
+++ b/checkly/resource_check_group.go
@@ -99,7 +99,7 @@ func resourceCheckGroup() *schema.Resource {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Description: "Setting this to `true` will trigger a retry when a check fails from the failing region and another, randomly selected region before marking the check as failed.",
-				Deprecated: "The property `double_check` is deprecated and will be removed in a future version. To enable retries for failed check runs, use the `retry_strategy` property instead.",
+				Deprecated:  "The property `double_check` is deprecated and will be removed in a future version. To enable retries for failed check runs, use the `retry_strategy` property instead.",
 			},
 			"tags": {
 				Type:     schema.TypeSet,
@@ -152,7 +152,7 @@ func resourceCheckGroup() *schema.Resource {
 				},
 			},
 			"alert_settings": {
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Optional: true,
 				Computed: true,
 				MaxItems: 1,
@@ -165,8 +165,9 @@ func resourceCheckGroup() *schema.Resource {
 							Description: "Determines what type of escalation to use. Possible values are `RUN_BASED` or `TIME_BASED`.",
 						},
 						"run_based_escalation": {
-							Type:     schema.TypeSet,
+							Type:     schema.TypeList,
 							Optional: true,
+							Computed: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"failed_run_threshold": {
@@ -178,8 +179,9 @@ func resourceCheckGroup() *schema.Resource {
 							},
 						},
 						"time_based_escalation": {
-							Type:     schema.TypeSet,
+							Type:     schema.TypeList,
 							Optional: true,
+							Computed: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"minutes_failing_threshold": {
@@ -191,8 +193,9 @@ func resourceCheckGroup() *schema.Resource {
 							},
 						},
 						"reminders": {
-							Type:     schema.TypeSet,
+							Type:     schema.TypeList,
 							Optional: true,
+							Computed: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"amount": {
@@ -210,8 +213,9 @@ func resourceCheckGroup() *schema.Resource {
 							},
 						},
 						"parallel_run_failure_threshold": {
-							Type:     schema.TypeSet,
+							Type:     schema.TypeList,
 							Optional: true,
+							Computed: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"enabled": {
@@ -534,7 +538,7 @@ func checkGroupFromResourceData(d *schema.ResourceData) (checkly.Group, error) {
 		TearDownSnippetID:         int64(d.Get("teardown_snippet_id").(int)),
 		LocalSetupScript:          d.Get("local_setup_script").(string),
 		LocalTearDownScript:       d.Get("local_teardown_script").(string),
-		AlertSettings:             alertSettingsFromSet(d.Get("alert_settings").(*schema.Set)),
+		AlertSettings:             alertSettingsFromSet(d.Get("alert_settings").([]interface{})),
 		UseGlobalAlertSettings:    d.Get("use_global_alert_settings").(bool),
 		APICheckDefaults:          apiCheckDefaultsFromSet(d.Get("api_check_defaults").(*schema.Set)),
 		AlertChannelSubscriptions: alertChannelSubscriptionsFromSet(d.Get("alert_channel_subscription").([]interface{})),

--- a/checkly/resource_heartbeat.go
+++ b/checkly/resource_heartbeat.go
@@ -49,7 +49,7 @@ func resourceHeartbeat() *schema.Resource {
 				Description: "A list of tags for organizing and filtering checks.",
 			},
 			"alert_settings": {
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Optional: true,
 				Computed: true,
 				MaxItems: 1,
@@ -61,8 +61,9 @@ func resourceHeartbeat() *schema.Resource {
 							Description: "Determines what type of escalation to use. Possible values are `RUN_BASED` or `TIME_BASED`.",
 						},
 						"run_based_escalation": {
-							Type:     schema.TypeSet,
+							Type:     schema.TypeList,
 							Optional: true,
+							Computed: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"failed_run_threshold": {
@@ -74,8 +75,9 @@ func resourceHeartbeat() *schema.Resource {
 							},
 						},
 						"time_based_escalation": {
-							Type:     schema.TypeSet,
+							Type:     schema.TypeList,
 							Optional: true,
+							Computed: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"minutes_failing_threshold": {
@@ -87,8 +89,9 @@ func resourceHeartbeat() *schema.Resource {
 							},
 						},
 						"reminders": {
-							Type:     schema.TypeSet,
+							Type:     schema.TypeList,
 							Optional: true,
+							Computed: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"amount": {
@@ -106,8 +109,9 @@ func resourceHeartbeat() *schema.Resource {
 							},
 						},
 						"parallel_run_failure_threshold": {
-							Type:     schema.TypeSet,
+							Type:     schema.TypeList,
 							Optional: true,
+							Computed: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"enabled": {

--- a/checkly/resource_heartbeat.go
+++ b/checkly/resource_heartbeat.go
@@ -174,8 +174,8 @@ func resourceHeartbeat() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"period": {
-							Type:     schema.TypeInt,
-							Required: true,
+							Type:        schema.TypeInt,
+							Required:    true,
 							Description: "How often you expect a ping to the ping URL.",
 						},
 						"period_unit": {
@@ -198,8 +198,8 @@ func resourceHeartbeat() *schema.Resource {
 							Description: "Possible values `seconds`, `minutes`, `hours` and `days`.",
 						},
 						"grace": {
-							Type:     schema.TypeInt,
-							Required: true,
+							Type:        schema.TypeInt,
+							Required:    true,
 							Description: "How long Checkly should wait before triggering any alerts when a ping does not arrive within the set period.",
 						},
 						"grace_unit": {
@@ -222,9 +222,9 @@ func resourceHeartbeat() *schema.Resource {
 							Description: "Possible values `seconds`, `minutes`, `hours` and `days`.",
 						},
 						"ping_token": {
-							Type:     schema.TypeString,
-							Optional: true,
-							Computed: true,
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true,
 							Description: "Custom token to generate your ping URL. Checkly will expect a ping to `https://ping.checklyhq.com/[PING_TOKEN]`.",
 						},
 					},
@@ -317,7 +317,7 @@ func heartbeatCheckFromResourceData(d *schema.ResourceData) (checkly.HeartbeatCh
 		Activated:                 d.Get("activated").(bool),
 		Muted:                     d.Get("muted").(bool),
 		Tags:                      stringsFromSet(d.Get("tags").(*schema.Set)),
-		AlertSettings:             alertSettingsFromSet(d.Get("alert_settings").(*schema.Set)),
+		AlertSettings:             alertSettingsFromSet(d.Get("alert_settings").([]interface{})),
 		UseGlobalAlertSettings:    d.Get("use_global_alert_settings").(bool),
 		AlertChannelSubscriptions: alertChannelSubscriptionsFromSet(d.Get("alert_channel_subscription").([]interface{})),
 	}


### PR DESCRIPTION
## Affected Components
* [ ] Resources
* [ ] Test
* [ ] Docs
* [ ] Tooling
* [ ] Other

## Pre-Requisites
* [ ] Terraform code is formatted with `terraform fmt`
* [ ] Go code is formatted with `go fmt`
* [ ] `plan` & `apply` command of `demo/main.tf` file do not produce diffs

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
* Turn TypeSet into TypeList in alert settings and the nested attirubtes in their so TF diff detection uses the position of the value instead of the hash of the value, this doesn't work well with computed values
* Add computed field to the alert settings fields so client state persists the server defaults