### PR TITLE
fix: use SSLCheckDomain instead of Type to set a browser check SSL do…

### DIFF
--- a/checkly/resource_check.go
+++ b/checkly/resource_check.go
@@ -650,7 +650,7 @@ func resourceDataFromCheck(c *checkly.Check, d *schema.ResourceData) error {
 
 	// ssl_check_domain is only supported for Browser checks
 	if c.Type == "BROWSER" && c.SSLCheckDomain != "" {
-		d.Set("ssl_check_domain", c.Type)
+		d.Set("ssl_check_domain", c.SSLCheckDomain)
 	}
 
 	environmentVariables := environmentVariablesFromSet(d.Get("environment_variable").([]interface{}))


### PR DESCRIPTION
…main

## Affected Components
* [x] Resources
* [ ] Test
* [ ] Docs
* [ ] Tooling
* [ ] Other

## Pre-Requisites
* [x] Terraform code is formatted with `terraform fmt`
* [x] Go code is formatted with `go fmt`
* [x] `plan` & `apply` command of `demo/main.tf` file do not produce diffs

## Notes for the Reviewer

[0x416e746f6e](https://github.com/0x416e746f6e) [fix](https://github.com/checkly/terraform-provider-checkly/pull/286) for SSL check domain permadiff.
