### PR TITLE
chore: apply terraform fmt to all examples

### DIFF
--- a/.github/workflows/terraform-format-and-style.yml
+++ b/.github/workflows/terraform-format-and-style.yml
@@ -1,0 +1,69 @@
+name: Terraform Format and Style
+on:
+  pull_request:
+    paths:
+      - '**.tf'
+      - '**.tfvars'
+      - '**.tftest.hcl'
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+    - uses: actions/checkout@v4
+    - uses: hashicorp/setup-terraform@v3
+
+    - name: terraform fmt
+      id: fmt
+      run: terraform fmt -check -recursive -diff
+      continue-on-error: true
+
+    - uses: actions/github-script@v7
+      if: github.event_name == 'pull_request'
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          // 1. Retrieve existing bot comments for the PR
+          const { data: comments } = await github.rest.issues.listComments({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: context.issue.number,
+          })
+          const botComment = comments.find(comment => {
+            return comment.user.type === 'Bot' && comment.body.includes('Terraform Format and Style')
+          })
+
+          // 2. Prepare format of the comment
+          const output = `#### Terraform Format and Style 🖌\`${{ steps.fmt.outcome }}\`
+          <details><summary>Format Output</summary>
+
+          \`\`\`diff\n
+          ${{ steps.fmt.outputs.stdout }}
+          \`\`\`
+
+          </details>`;
+
+          // 3. If we have a comment, update it, otherwise create a new one
+          if (botComment) {
+            github.rest.issues.updateComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: botComment.id,
+              body: output
+            })
+          } else {
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: output
+            })
+          }
+
+    - name: Fail on formatting error
+      if: ${{ steps.fmt.outcome != 'success' }}
+      run: |
+        echo "::error title=Terraform::Unresolved formatting errors are present"
+        exit 1

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,7 +36,7 @@ variable "checkly_account_id" {}
 terraform {
   required_providers {
     checkly = {
-      source = "checkly/checkly"
+      source  = "checkly/checkly"
       version = "1.7.1"
     }
   }
@@ -44,7 +44,7 @@ terraform {
 
 # Pass the API Key environment variable to the provider
 provider "checkly" {
-  api_key = var.checkly_api_key
+  api_key    = var.checkly_api_key
   account_id = var.checkly_account_id
 }
 

--- a/docs/resources/alert_channel.md
+++ b/docs/resources/alert_channel.md
@@ -18,37 +18,37 @@ resource "checkly_alert_channel" "email_ac" {
   email {
     address = "john@example.com"
   }
-  send_recovery = true
-  send_failure = false
-  send_degraded = true
-  ssl_expiry = true
+  send_recovery        = true
+  send_failure         = false
+  send_degraded        = true
+  ssl_expiry           = true
   ssl_expiry_threshold = 22
 }
 
 # A SMS alert channel
 resource "checkly_alert_channel" "sms_ac" {
   sms {
-    name = "john"
+    name   = "john"
     number = "+5491100001111"
   }
   send_recovery = true
-  send_failure = true
+  send_failure  = true
 }
 
 # A Slack alert channel
 resource "checkly_alert_channel" "slack_ac" {
   slack {
     channel = "#checkly-notifications"
-    url = "https://hooks.slack.com/services/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"
+    url     = "https://hooks.slack.com/services/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"
   }
 }
 
 # An Opsgenie alert channel
 resource "checkly_alert_channel" "opsgenie_ac" {
   opsgenie {
-    name = "opsalerts"
-    api_key = "fookey"
-    region = "fooregion"
+    name     = "opsalerts"
+    api_key  = "fookey"
+    region   = "fooregion"
     priority = "foopriority"
   }
 }
@@ -65,10 +65,10 @@ resource "checkly_alert_channel" "pagerduty_ac" {
 # A Webhook alert channel
 resource "checkly_alert_channel" "webhook_ac" {
   webhook {
-    name = "foo"
-    method = "get"
-    template = "footemplate"
-    url = "https://example.com/foo"
+    name           = "foo"
+    method         = "get"
+    template       = "footemplate"
+    url            = "https://example.com/foo"
     webhook_secret = "foosecret"
   }
 }

--- a/docs/resources/check.md
+++ b/docs/resources/check.md
@@ -67,11 +67,11 @@ resource "checkly_check" "example_check_2" {
   }
 
   retry_strategy {
-    type = "FIXED"
+    type                 = "FIXED"
     base_backoff_seconds = 60
     max_duration_seconds = 600
-    max_retries = 3
-    same_region = false
+    max_retries          = 3
+    same_region          = false
   }
 
   request {

--- a/docs/resources/check_group.md
+++ b/docs/resources/check_group.md
@@ -87,17 +87,17 @@ resource "checkly_check_group" "test_group1" {
 
 # Add a check to a group
 resource "checkly_check" "test_check1" {
-  name        = "My test check 1"
-  type        = "API"
-  activated   = true
-  frequency   = 1
+  name      = "My test check 1"
+  type      = "API"
+  activated = true
+  frequency = 1
 
   locations = [
     "us-west-1"
   ]
 
   request {
-    url              = "https://api.example.com/"
+    url = "https://api.example.com/"
   }
   group_id    = checkly_check_group.test_group1.id
   group_order = 1
@@ -120,7 +120,7 @@ resource "checkly_alert_channel" "email_ac2" {
 
 # Connect the check group to the alert channels
 resource "checkly_check_group" "test_group1" {
-  name      = "My test group 1"
+  name = "My test group 1"
 
   alert_channel_subscription {
     channel_id = checkly_alert_channel.email_ac1.id

--- a/docs/resources/environment_variable.md
+++ b/docs/resources/environment_variable.md
@@ -15,13 +15,13 @@ description: |-
 ```terraform
 # Simple Enviroment Variable example
 resource "checkly_environment_variable" "variable_1" {
-  key = "API_KEY"
-  value = "loZd9hOGHDUrGvmW"
+  key    = "API_KEY"
+  value  = "loZd9hOGHDUrGvmW"
   locked = true
 }
 
 resource "checkly_environment_variable" "variable_2" {
-  key = "API_URL"
+  key   = "API_URL"
   value = "http://localhost:3000"
 }
 ```

--- a/docs/resources/heartbeat.md
+++ b/docs/resources/heartbeat.md
@@ -14,13 +14,13 @@ Heartbeats allows you to monitor your cron jobs and set up alerting, so you get 
 
 ```terraform
 resource "checkly_heartbeat" "example-heartbeat" {
-  name                      = "Example heartbeat"
-  activated                 = true
+  name      = "Example heartbeat"
+  activated = true
   heartbeat {
-    period                  = 7
-    period_unit             = "days"
-    grace                   = 1
-    grace_unit              = "days"
+    period      = 7
+    period_unit = "days"
+    grace       = 1
+    grace_unit  = "days"
   }
   use_global_alert_settings = true
 }

--- a/docs/resources/private_location.md
+++ b/docs/resources/private_location.md
@@ -14,8 +14,8 @@ description: |-
 
 ```terraform
 resource "checkly_private_location" "location" {
-  name          = "New Private Location"
-  slug_name     = "new-private-location"
+  name      = "New Private Location"
+  slug_name = "new-private-location"
 }
 ```
 

--- a/docs/resources/snippet.md
+++ b/docs/resources/snippet.md
@@ -15,13 +15,13 @@ description: |-
 ```terraform
 resource "checkly_snippet" "example_1" {
   name   = "Example 1"
-  script   = "console.log('test');"
+  script = "console.log('test');"
 }
 
 # An alternative way to use multi-line script.
 resource "checkly_snippet" "example_2" {
   name   = "Example 2"
-  script   = <<EOT
+  script = <<EOT
     console.log('test1');
     console.log('test2');
 EOT

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -6,7 +6,7 @@ variable "checkly_account_id" {}
 terraform {
   required_providers {
     checkly = {
-      source = "checkly/checkly"
+      source  = "checkly/checkly"
       version = "1.7.1"
     }
   }
@@ -14,7 +14,7 @@ terraform {
 
 # Pass the API Key environment variable to the provider
 provider "checkly" {
-  api_key = var.checkly_api_key
+  api_key    = var.checkly_api_key
   account_id = var.checkly_account_id
 }
 

--- a/examples/resources/checkly_alert_channel/resource.tf
+++ b/examples/resources/checkly_alert_channel/resource.tf
@@ -3,37 +3,37 @@ resource "checkly_alert_channel" "email_ac" {
   email {
     address = "john@example.com"
   }
-  send_recovery = true
-  send_failure = false
-  send_degraded = true
-  ssl_expiry = true
+  send_recovery        = true
+  send_failure         = false
+  send_degraded        = true
+  ssl_expiry           = true
   ssl_expiry_threshold = 22
 }
 
 # A SMS alert channel
 resource "checkly_alert_channel" "sms_ac" {
   sms {
-    name = "john"
+    name   = "john"
     number = "+5491100001111"
   }
   send_recovery = true
-  send_failure = true
+  send_failure  = true
 }
 
 # A Slack alert channel
 resource "checkly_alert_channel" "slack_ac" {
   slack {
     channel = "#checkly-notifications"
-    url = "https://hooks.slack.com/services/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"
+    url     = "https://hooks.slack.com/services/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"
   }
 }
 
 # An Opsgenie alert channel
 resource "checkly_alert_channel" "opsgenie_ac" {
   opsgenie {
-    name = "opsalerts"
-    api_key = "fookey"
-    region = "fooregion"
+    name     = "opsalerts"
+    api_key  = "fookey"
+    region   = "fooregion"
     priority = "foopriority"
   }
 }
@@ -50,10 +50,10 @@ resource "checkly_alert_channel" "pagerduty_ac" {
 # A Webhook alert channel
 resource "checkly_alert_channel" "webhook_ac" {
   webhook {
-    name = "foo"
-    method = "get"
-    template = "footemplate"
-    url = "https://example.com/foo"
+    name           = "foo"
+    method         = "get"
+    template       = "footemplate"
+    url            = "https://example.com/foo"
     webhook_secret = "foosecret"
   }
 }

--- a/examples/resources/checkly_check/resource.tf
+++ b/examples/resources/checkly_check/resource.tf
@@ -52,11 +52,11 @@ resource "checkly_check" "example_check_2" {
   }
 
   retry_strategy {
-    type = "FIXED"
+    type                 = "FIXED"
     base_backoff_seconds = 60
     max_duration_seconds = 600
-    max_retries = 3
-    same_region = false
+    max_retries          = 3
+    same_region          = false
   }
 
   request {

--- a/examples/resources/checkly_check_group/resource.tf
+++ b/examples/resources/checkly_check_group/resource.tf
@@ -72,17 +72,17 @@ resource "checkly_check_group" "test_group1" {
 
 # Add a check to a group
 resource "checkly_check" "test_check1" {
-  name        = "My test check 1"
-  type        = "API"
-  activated   = true
-  frequency   = 1
+  name      = "My test check 1"
+  type      = "API"
+  activated = true
+  frequency = 1
 
   locations = [
     "us-west-1"
   ]
 
   request {
-    url              = "https://api.example.com/"
+    url = "https://api.example.com/"
   }
   group_id    = checkly_check_group.test_group1.id
   group_order = 1
@@ -105,7 +105,7 @@ resource "checkly_alert_channel" "email_ac2" {
 
 # Connect the check group to the alert channels
 resource "checkly_check_group" "test_group1" {
-  name      = "My test group 1"
+  name = "My test group 1"
 
   alert_channel_subscription {
     channel_id = checkly_alert_channel.email_ac1.id

--- a/examples/resources/checkly_environment_variable/resource.tf
+++ b/examples/resources/checkly_environment_variable/resource.tf
@@ -1,11 +1,11 @@
 # Simple Enviroment Variable example
 resource "checkly_environment_variable" "variable_1" {
-  key = "API_KEY"
-  value = "loZd9hOGHDUrGvmW"
+  key    = "API_KEY"
+  value  = "loZd9hOGHDUrGvmW"
   locked = true
 }
 
 resource "checkly_environment_variable" "variable_2" {
-  key = "API_URL"
+  key   = "API_URL"
   value = "http://localhost:3000"
 }

--- a/examples/resources/checkly_heartbeat/resource.tf
+++ b/examples/resources/checkly_heartbeat/resource.tf
@@ -1,11 +1,11 @@
 resource "checkly_heartbeat" "example-heartbeat" {
-  name                      = "Example heartbeat"
-  activated                 = true
+  name      = "Example heartbeat"
+  activated = true
   heartbeat {
-    period                  = 7
-    period_unit             = "days"
-    grace                   = 1
-    grace_unit              = "days"
+    period      = 7
+    period_unit = "days"
+    grace       = 1
+    grace_unit  = "days"
   }
   use_global_alert_settings = true
 }

--- a/examples/resources/checkly_private_location/resource.tf
+++ b/examples/resources/checkly_private_location/resource.tf
@@ -1,4 +1,4 @@
 resource "checkly_private_location" "location" {
-  name          = "New Private Location"
-  slug_name     = "new-private-location"
+  name      = "New Private Location"
+  slug_name = "new-private-location"
 }

--- a/examples/resources/checkly_snippet/resource.tf
+++ b/examples/resources/checkly_snippet/resource.tf
@@ -1,12 +1,12 @@
 resource "checkly_snippet" "example_1" {
   name   = "Example 1"
-  script   = "console.log('test');"
+  script = "console.log('test');"
 }
 
 # An alternative way to use multi-line script.
 resource "checkly_snippet" "example_2" {
   name   = "Example 2"
-  script   = <<EOT
+  script = <<EOT
     console.log('test1');
     console.log('test2');
 EOT


### PR DESCRIPTION
Currently, examples are not formatted with `terraform fmt`, which makes further tooling changes annoying.

This PR applies proper formatting to examples, and adds a new GitHub workflow that comments on PRs that change Terraform files with the result of `terraform fmt` and reports a failing check. I have tested the workflow by pushing commits with incorrect formatting (and then removing those commits again which is why they cannot be seen).

## Affected Components
* [ ] Resources
* [ ] Test
* [ ] Docs
* [ ] Tooling
* [x] Other

## Pre-Requisites
* [x] Terraform code is formatted with `terraform fmt`
* [ ] Go code is formatted with `go fmt`
* [ ] `plan` & `apply` command of `demo/main.tf` file do not produce diffs

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #[issue-number]

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
