### PR TITLE
fix: use updated limits for TCP check degraded/max response time [sc-23431]

### DIFF
--- a/checkly/resource_tcp_check.go
+++ b/checkly/resource_tcp_check.go
@@ -83,30 +83,28 @@ func resourceTCPCheck() *schema.Resource {
 			"degraded_response_time": {
 				Type:     schema.TypeInt,
 				Optional: true,
-				Default:  15000,
+				Default:  4000,
 				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
-					// https://checklyhq.com/docs/api-checks/limits/
 					v := val.(int)
-					if v < 0 || v > 30000 {
-						errs = append(errs, fmt.Errorf("%q must be 0-30000 ms, got %d", key, v))
+					if v < 0 || v > 5000 {
+						errs = append(errs, fmt.Errorf("%q must be 0-5000 ms, got %d", key, v))
 					}
 					return warns, errs
 				},
-				Description: "The response time in milliseconds starting from which a check should be considered degraded. Possible values are between 0 and 30000. (Default `15000`).",
+				Description: "The response time in milliseconds starting from which a check should be considered degraded. Possible values are between 0 and 5000. (Default `4000`).",
 			},
 			"max_response_time": {
 				Type:     schema.TypeInt,
 				Optional: true,
-				Default:  30000,
+				Default:  5000,
 				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
 					v := val.(int)
-					// https://checklyhq.com/docs/api-checks/limits/
-					if v < 0 || v > 30000 {
-						errs = append(errs, fmt.Errorf("%q must be 0-30000 ms, got: %d", key, v))
+					if v < 0 || v > 5000 {
+						errs = append(errs, fmt.Errorf("%q must be 0-5000 ms, got: %d", key, v))
 					}
 					return warns, errs
 				},
-				Description: "The response time in milliseconds starting from which a check should be considered failing. Possible values are between 0 and 30000. (Default `30000`).",
+				Description: "The response time in milliseconds starting from which a check should be considered failing. Possible values are between 0 and 5000. (Default `5000`).",
 			},
 			"tags": {
 				Type:     schema.TypeSet,

--- a/checkly/resource_tcp_check_test.go
+++ b/checkly/resource_tcp_check_test.go
@@ -100,12 +100,12 @@ func TestAccTCPCheckFull(t *testing.T) {
 				resource.TestCheckResourceAttr(
 					"checkly_tcp_check.test",
 					"degraded_response_time",
-					"15000",
+					"4000",
 				),
 				resource.TestCheckResourceAttr(
 					"checkly_tcp_check.test",
 					"max_response_time",
-					"30000",
+					"5000",
 				),
 				testCheckResourceAttrExpr(
 					"checkly_tcp_check.test",
@@ -150,8 +150,8 @@ var wantTCPCheck = checkly.TCPCheck{
 	ShouldFail:           false,
 	Locations:            []string{"eu-west-1"},
 	PrivateLocations:     &[]string{},
-	DegradedResponseTime: 15000,
-	MaxResponseTime:      30000,
+	DegradedResponseTime: 4000,
+	MaxResponseTime:      5000,
 	Tags: []string{
 		"foo",
 		"bar",
@@ -199,7 +199,7 @@ const tcpCheck_basic = `
 	  frequency                 = 60
 	  activated                 = true
 	  muted                     = true
-	  max_response_time         = 18000
+	  max_response_time         = 3000
 	  locations                 = [ "us-east-1", "eu-central-1" ]
 	  use_global_alert_settings = true
 	  request {
@@ -221,8 +221,8 @@ const tcpCheck_full = `
 	frequency              = 120
 	activated              = true
 	muted                  = true
-	degraded_response_time = 15000
-	max_response_time      = 30000
+	degraded_response_time = 4000
+	max_response_time      = 5000
 	locations = [
 	  "eu-central-1",
 	  "us-east-1",

--- a/docs/resources/tcp_check.md
+++ b/docs/resources/tcp_check.md
@@ -102,12 +102,12 @@ resource "checkly_tcp_check" "example-tcp-check-2" {
 
 - `alert_channel_subscription` (Block List) An array of channel IDs and whether they're activated or not. If you don't set at least one alert subscription for your check, we won't be able to alert you in case something goes wrong with it. (see [below for nested schema](#nestedblock--alert_channel_subscription))
 - `alert_settings` (Block List, Max: 1) (see [below for nested schema](#nestedblock--alert_settings))
-- `degraded_response_time` (Number) The response time in milliseconds starting from which a check should be considered degraded. Possible values are between 0 and 30000. (Default `15000`).
+- `degraded_response_time` (Number) The response time in milliseconds starting from which a check should be considered degraded. Possible values are between 0 and 5000. (Default `4000`).
 - `frequency_offset` (Number) To create a high frequency check, the property `frequency` must be `0` and `frequency_offset` can be `10`, `20` or `30`.
 - `group_id` (Number) The id of the check group this check is part of.
 - `group_order` (Number) The position of this check in a check group. It determines in what order checks are run when a group is triggered from the API or from CI/CD.
 - `locations` (Set of String) An array of one or more data center locations where to run the this check. (Default ["us-east-1"])
-- `max_response_time` (Number) The response time in milliseconds starting from which a check should be considered failing. Possible values are between 0 and 30000. (Default `30000`).
+- `max_response_time` (Number) The response time in milliseconds starting from which a check should be considered failing. Possible values are between 0 and 5000. (Default `5000`).
 - `muted` (Boolean) Determines if any notifications will be sent out when a check fails/degrades/recovers.
 - `private_locations` (Set of String) An array of one or more private locations slugs.
 - `retry_strategy` (Block Set, Max: 1) A strategy for retrying failed check runs. (see [below for nested schema](#nestedblock--retry_strategy))


### PR DESCRIPTION
The maximum values were reduced at the backend level and the defaults were changed as well. This change syncs both values to current values used by the backend.

This change is technically backwards incompatible, but even the current version is broken right now if the user relies on default values.

## Affected Components
* [x] Resources
* [x] Test
* [x] Docs
* [ ] Tooling
* [ ] Other

## Pre-Requisites
* [x] Terraform code is formatted with `terraform fmt`
* [x] Go code is formatted with `go fmt`
* [ ] `plan` & `apply` command of `demo/main.tf` file do not produce diffs

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #[issue-number]

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
