### PR TITLE
fix: always keep original client certificate key, backend no longer returns it [sc-23507]

### DIFF
--- a/checkly/resource_client_certificate.go
+++ b/checkly/resource_client_certificate.go
@@ -94,7 +94,10 @@ func clientCertificateFromResourceData(d *schema.ResourceData) (checkly.ClientCe
 func resourceDataFromClientCertificate(c *checkly.ClientCertificate, d *schema.ResourceData) error {
 	d.Set("host", c.Host)
 	d.Set("certificate", c.Certificate)
-	d.Set("private_key", c.PrivateKey)
+	// The backend does not return a value for PrivateKey anymore, though it
+	// used to. The value should not change by itself, so we can simply keep
+	// the original state.
+	// d.Set("private_key", c.PrivateKey)
 	d.Set("trusted_ca", c.TrustedCA)
 	// The backend does not return a value for Passphrase and even it did, the
 	// value would be encrypted. Thus, the value should never be modified.


### PR DESCRIPTION
This change makes it so that a `checkly_client_certificate`'s `private_key` is no longer updated based on the backend response. The backend no longer returns a value for this field.

## Affected Components
* [x] Resources
* [ ] Test
* [ ] Docs
* [ ] Tooling
* [ ] Other

## Pre-Requisites
* [x] Terraform code is formatted with `terraform fmt`
* [x] Go code is formatted with `go fmt`
* [ ] `plan` & `apply` command of `demo/main.tf` file do not produce diffs

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #[issue-number]

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
