### PR TITLE
feat: add support for enable_incidents and other dashboard properties [sc-25022]

### DIFF
--- a/checkly/resource_dashboard_test.go
+++ b/checkly/resource_dashboard_test.go
@@ -1,0 +1,656 @@
+package checkly
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccDashboardCheckRequiredFields(t *testing.T) {
+	config := `resource "checkly_dashboard" "test" {}`
+	accTestCase(t, []resource.TestStep{
+		{
+			Config:      config,
+			ExpectError: regexp.MustCompile(`The argument "custom_url" is required`),
+		},
+		{
+			Config:      config,
+			ExpectError: regexp.MustCompile(`The argument "header" is required`),
+		},
+	})
+}
+
+func TestAccDashboardMinimalConfig(t *testing.T) {
+	accTestCase(t, []resource.TestStep{
+		{
+			Config: `
+				resource "checkly_dashboard" "test" {
+					custom_url = "test-dashboard-795115703-minimal"
+					header     = "Minimal Dashboard"
+				}
+			`,
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr(
+					"checkly_dashboard.test",
+					"custom_url",
+					"test-dashboard-795115703-minimal",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_dashboard.test",
+					"logo",
+					"",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_dashboard.test",
+					"favicon",
+					"",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_dashboard.test",
+					"link",
+					"",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_dashboard.test",
+					"description",
+					"",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_dashboard.test",
+					"header",
+					"Minimal Dashboard",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_dashboard.test",
+					"width",
+					"FULL",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_dashboard.test",
+					"refresh_rate",
+					"60",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_dashboard.test",
+					"paginate",
+					"true",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_dashboard.test",
+					"checks_per_page",
+					"15",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_dashboard.test",
+					"pagination_rate",
+					"60",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_dashboard.test",
+					"hide_tags",
+					"false",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_dashboard.test",
+					"use_tags_and_operator",
+					"false",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_dashboard.test",
+					"enable_incidents",
+					"false",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_dashboard.test",
+					"is_private",
+					"false",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_dashboard.test",
+					"show_header",
+					"true",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_dashboard.test",
+					"expand_checks",
+					"false",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_dashboard.test",
+					"show_check_run_links",
+					"false",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_dashboard.test",
+					"custom_css",
+					"",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_dashboard.test",
+					"show_p95",
+					"true",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_dashboard.test",
+					"show_p99",
+					"true",
+				),
+			),
+		},
+	})
+}
+
+func TestAccDashboardFullConfig(t *testing.T) {
+	accTestCase(t, []resource.TestStep{
+		{
+			Config: `
+				resource "checkly_dashboard" "test" {
+					custom_url            = "test-dashboard-795115703-full"
+					custom_domain         = "status-795115703.example.com"
+					logo                  = "https://example.com/logo.png"
+					favicon               = "https://example.com/favicon.ico"
+					link                  = "https://example.com"
+					description           = "Test dashboard description"
+					header                = "System Status"
+					show_header           = false
+					width                 = "960PX"
+					refresh_rate          = 300
+					paginate              = false
+					checks_per_page       = 20
+					pagination_rate       = 30
+					hide_tags             = true
+					use_tags_and_operator = true
+					enable_incidents      = true
+					expand_checks         = true
+					show_check_run_links  = true
+					custom_css            = ".header { color: blue; }"
+					show_p95              = false
+					show_p99              = false
+					tags                  = ["production", "api"]
+				}
+			`,
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr(
+					"checkly_dashboard.test",
+					"custom_url",
+					"test-dashboard-795115703-full",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_dashboard.test",
+					"custom_domain",
+					"status-795115703.example.com",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_dashboard.test",
+					"logo",
+					"https://example.com/logo.png",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_dashboard.test",
+					"favicon",
+					"https://example.com/favicon.ico",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_dashboard.test",
+					"link",
+					"https://example.com",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_dashboard.test",
+					"description",
+					"Test dashboard description",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_dashboard.test",
+					"header",
+					"System Status",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_dashboard.test",
+					"width",
+					"960PX",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_dashboard.test",
+					"refresh_rate",
+					"300",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_dashboard.test",
+					"paginate",
+					"false",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_dashboard.test",
+					"checks_per_page",
+					"20",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_dashboard.test",
+					"pagination_rate",
+					"30",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_dashboard.test",
+					"hide_tags",
+					"true",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_dashboard.test",
+					"use_tags_and_operator",
+					"true",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_dashboard.test",
+					"enable_incidents",
+					"true",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_dashboard.test",
+					"tags.#",
+					"2",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_dashboard.test",
+					"show_header",
+					"false",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_dashboard.test",
+					"expand_checks",
+					"true",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_dashboard.test",
+					"show_check_run_links",
+					"true",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_dashboard.test",
+					"custom_css",
+					".header { color: blue; }",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_dashboard.test",
+					"show_p95",
+					"false",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_dashboard.test",
+					"show_p99",
+					"false",
+				),
+			),
+		},
+		{
+			Config: `
+				resource "checkly_dashboard" "test" {
+					custom_url            = "test-dashboard-795115703-full-updated"
+					custom_domain         = "status-795115703.example.com" # Cannot be modified for a few minutes.
+					logo                  = "https://example.com/logo2.png"
+					favicon               = "https://example.com/favicon2.ico"
+					link                  = "https://example2.com"
+					description           = "Updated test dashboard description"
+					header                = "Updated System Status"
+					show_header           = true
+					width                 = "FULL"
+					refresh_rate          = 600
+					paginate              = true
+					checks_per_page       = 10
+					pagination_rate       = 300
+					hide_tags             = false
+					use_tags_and_operator = false
+					enable_incidents      = false
+					expand_checks         = false
+					show_check_run_links  = false
+					custom_css            = "body { background: #f0f0f0; }"
+					show_p95              = true
+					show_p99              = true
+					tags                  = ["staging"]
+				}
+			`,
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr(
+					"checkly_dashboard.test",
+					"custom_url",
+					"test-dashboard-795115703-full-updated",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_dashboard.test",
+					"custom_domain",
+					// The backend won't let us modify a custom domain for
+					// a few minutes, so we're not testing a new value here.
+					"status-795115703.example.com",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_dashboard.test",
+					"logo",
+					"https://example.com/logo2.png",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_dashboard.test",
+					"favicon",
+					"https://example.com/favicon2.ico",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_dashboard.test",
+					"link",
+					"https://example2.com",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_dashboard.test",
+					"description",
+					"Updated test dashboard description",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_dashboard.test",
+					"header",
+					"Updated System Status",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_dashboard.test",
+					"width",
+					"FULL",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_dashboard.test",
+					"refresh_rate",
+					"600",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_dashboard.test",
+					"paginate",
+					"true",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_dashboard.test",
+					"checks_per_page",
+					"10",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_dashboard.test",
+					"pagination_rate",
+					"300",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_dashboard.test",
+					"hide_tags",
+					"false",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_dashboard.test",
+					"use_tags_and_operator",
+					"false",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_dashboard.test",
+					"enable_incidents",
+					"false",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_dashboard.test",
+					"tags.#",
+					"1",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_dashboard.test",
+					"show_header",
+					"true",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_dashboard.test",
+					"expand_checks",
+					"false",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_dashboard.test",
+					"show_check_run_links",
+					"false",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_dashboard.test",
+					"custom_css",
+					"body { background: #f0f0f0; }",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_dashboard.test",
+					"show_p95",
+					"true",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_dashboard.test",
+					"show_p99",
+					"true",
+				),
+			),
+		},
+	})
+}
+
+func TestAccDashboardPrivateDashboard(t *testing.T) {
+	accTestCase(t, []resource.TestStep{
+		{
+			Config: `
+				resource "checkly_dashboard" "test" {
+					custom_url = "test-dashboard-795115703-private"
+					header     = "Private Dashboard"
+					is_private = true
+				}
+			`,
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr(
+					"checkly_dashboard.test",
+					"custom_url",
+					"test-dashboard-795115703-private",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_dashboard.test",
+					"is_private",
+					"true",
+				),
+				resource.TestCheckResourceAttrSet(
+					"checkly_dashboard.test",
+					"key",
+				),
+			),
+		},
+		{
+			Config: `
+				resource "checkly_dashboard" "test" {
+					custom_url = "test-dashboard-795115703-private"
+					header     = "Private Dashboard"
+					is_private = false
+				}
+			`,
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr(
+					"checkly_dashboard.test",
+					"is_private",
+					"false",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_dashboard.test",
+					"key",
+					"",
+				),
+			),
+		},
+	})
+}
+
+func TestAccDashboardInvalidWidth(t *testing.T) {
+	config := `
+		resource "checkly_dashboard" "test" {
+			custom_url = "test-dashboard-795115703-invalid-width"
+			header     = "Invalid Width Test"
+			width      = "500PX"
+		}
+	`
+	accTestCase(t, []resource.TestStep{
+		{
+			Config:      config,
+			ExpectError: regexp.MustCompile(`"width" must be one of \[FULL 960PX\], got: 500PX`),
+		},
+	})
+}
+
+func TestAccDashboardInvalidRefreshRate(t *testing.T) {
+	config := `
+		resource "checkly_dashboard" "test" {
+			custom_url   = "test-dashboard-795115703-invalid-refresh"
+			header       = "Invalid Refresh Test"
+			refresh_rate = 120
+		}
+	`
+	accTestCase(t, []resource.TestStep{
+		{
+			Config:      config,
+			ExpectError: regexp.MustCompile(`"refresh_rate" must be one of \[60 300 600\], got: 120`),
+		},
+	})
+}
+
+func TestAccDashboardInvalidPaginationRate(t *testing.T) {
+	config := `
+		resource "checkly_dashboard" "test" {
+			custom_url      = "test-dashboard-795115703-invalid-pagination"
+			header          = "Invalid Pagination Test"
+			pagination_rate = 90
+		}
+	`
+	accTestCase(t, []resource.TestStep{
+		{
+			Config:      config,
+			ExpectError: regexp.MustCompile(`"pagination_rate" must be one of \[30 60 300\], got: 90`),
+		},
+	})
+}
+
+func TestAccDashboardInvalidChecksPerPage(t *testing.T) {
+	config := `
+		resource "checkly_dashboard" "test" {
+			custom_url      = "test-dashboard-795115703-invalid-checks-per-page"
+			header          = "Invalid Checks Per Page Test"
+			checks_per_page = 25
+		}
+	`
+	accTestCase(t, []resource.TestStep{
+		{
+			Config:      config,
+			ExpectError: regexp.MustCompile(`"checks_per_page" must be between 1 and 20, got: 25`),
+		},
+	})
+}
+
+func TestAccDashboardWithCheckGroup(t *testing.T) {
+	accTestCase(t, []resource.TestStep{
+		{
+			Config: `
+				resource "checkly_check_group" "test" {
+					name        = "Test Group for Dashboard"
+					activated   = true
+					tags        = ["api", "production"]
+					locations   = ["us-east-1"]
+					concurrency = 3
+				}
+
+				resource "checkly_dashboard" "test" {
+					custom_url = "test-dashboard-795115703-with-tags"
+					header     = "Dashboard with Tags"
+					tags       = ["api", "production"]
+
+					use_tags_and_operator = true
+				}
+			`,
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr(
+					"checkly_dashboard.test",
+					"custom_url",
+					"test-dashboard-795115703-with-tags",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_dashboard.test",
+					"tags.#",
+					"2",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_dashboard.test",
+					"use_tags_and_operator",
+					"true",
+				),
+			),
+		},
+	})
+}
+
+func TestAccDashboardCustomCSS(t *testing.T) {
+	accTestCase(t, []resource.TestStep{
+		{
+			Config: `
+				resource "checkly_dashboard" "test" {
+					custom_url = "test-dashboard-795115703-custom-css"
+					header     = "Dashboard with Custom CSS"
+					custom_css = <<-EOT
+						body {
+							background-color: #f5f5f5;
+							font-family: Arial, sans-serif;
+						}
+						.header {
+							color: #333;
+							font-size: 24px;
+							margin-bottom: 20px;
+						}
+						.check-item {
+							border: 1px solid #ddd;
+							padding: 10px;
+							margin: 5px 0;
+						}
+					EOT
+				}
+			`,
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr(
+					"checkly_dashboard.test",
+					"custom_url",
+					"test-dashboard-795115703-custom-css",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_dashboard.test",
+					"custom_css",
+					`body {
+	background-color: #f5f5f5;
+	font-family: Arial, sans-serif;
+}
+.header {
+	color: #333;
+	font-size: 24px;
+	margin-bottom: 20px;
+}
+.check-item {
+	border: 1px solid #ddd;
+	padding: 10px;
+	margin: 5px 0;
+}
+`,
+				),
+			),
+		},
+		{
+			Config: `
+				resource "checkly_dashboard" "test" {
+					custom_url = "test-dashboard-795115703-custom-css"
+					header     = "Dashboard with Custom CSS"
+					custom_css = ""
+				}
+			`,
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr(
+					"checkly_dashboard.test",
+					"custom_css",
+					"",
+				),
+			),
+		},
+	})
+}

--- a/docs/resources/dashboard.md
+++ b/docs/resources/dashboard.md
@@ -35,24 +35,31 @@ resource "checkly_dashboard" "dashboard_1" {
 ### Required
 
 - `custom_url` (String) A subdomain name under 'checklyhq.com'. Needs to be unique across all users.
+- `header` (String) A piece of text displayed at the top of your dashboard.
 
 ### Optional
 
-- `checks_per_page` (Number) Determines how many checks to show per page.
+- `checks_per_page` (Number) Determines how many checks to show per page. Possible values are between 1 and 20. (Default `15`).
+- `custom_css` (String) Custom CSS to be applied to the dashboard.
 - `custom_domain` (String) A custom user domain, e.g. 'status.example.com'. See the docs on updating your DNS and SSL usage.
 - `description` (String) HTML <meta> description for the dashboard.
+- `enable_incidents` (Boolean) Enable incident support for the dashboard. (Default `false`).
+- `expand_checks` (Boolean) Expand or collapse checks on the dashboard. (Default `false`).
 - `favicon` (String) A URL pointing to an image file to use as browser favicon.
-- `header` (String) A piece of text displayed at the top of your dashboard.
-- `hide_tags` (Boolean) Show or hide the tags on the dashboard.
+- `hide_tags` (Boolean) Show or hide the tags on the dashboard. (Default `false`).
 - `is_private` (Boolean) Set your dashboard as private and generate key.
 - `link` (String) A link to for the dashboard logo.
 - `logo` (String) A URL pointing to an image file to use for the dashboard logo.
-- `paginate` (Boolean) Determines if pagination is on or off.
-- `pagination_rate` (Number) How often to trigger pagination in seconds. Possible values `30`, `60` and `300`.
-- `refresh_rate` (Number) How often to refresh the dashboard in seconds. Possible values `60`, '300' and `600`.
+- `paginate` (Boolean) Determines if pagination is on or off. (Default `true`).
+- `pagination_rate` (Number) How often to trigger pagination in seconds. Possible values `30`, `60` and `300`. (Default `60`).
+- `refresh_rate` (Number) How often to refresh the dashboard in seconds. Possible values `60`, '300' and `600`. (Default `60`).
+- `show_check_run_links` (Boolean) Show or hide check run links on the dashboard. (Default `false`).
+- `show_header` (Boolean) Show or hide header and description on the dashboard. (Default `true`).
+- `show_p95` (Boolean) Show or hide the P95 stats on the dashboard. (Default `true`).
+- `show_p99` (Boolean) Show or hide the P99 stats on the dashboard. (Default `true`).
 - `tags` (Set of String) A list of one or more tags that filter which checks to display on the dashboard.
-- `use_tags_and_operator` (Boolean) Set when to use AND operator for fetching dashboard tags.
-- `width` (String) Determines whether to use the full screen or focus in the center. Possible values `FULL` and `960PX`.
+- `use_tags_and_operator` (Boolean) Set when to use AND operator for fetching dashboard tags. (Default `false`).
+- `width` (String) Determines whether to use the full screen or focus in the center. Possible values are `FULL` and `960PX`. (Default `FULL`).
 
 ### Read-Only
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.22
 
 require (
 	github.com/aws/aws-sdk-go v1.44.122 // indirect
-	github.com/checkly/checkly-go-sdk v1.12.0
+	github.com/checkly/checkly-go-sdk v1.13.0
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/google/go-cmp v0.6.0
 	github.com/gruntwork-io/terratest v0.41.16

--- a/go.sum
+++ b/go.sum
@@ -240,8 +240,8 @@ github.com/bmatcuk/doublestar/v4 v4.6.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTS
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/checkly/checkly-go-sdk v1.12.0 h1:6oMBYEnhIlGd0Jf55ehGyjdJsqgtFQZ8Wk/n00520eA=
-github.com/checkly/checkly-go-sdk v1.12.0/go.mod h1:Pd6tBOggAe41NnCU5KwqA8JvD6J20/IctszT2E0AvHo=
+github.com/checkly/checkly-go-sdk v1.13.0 h1:LoQaj87fEcb7xTie7Z02rNfO1FqrwBti8wuBeINCGx0=
+github.com/checkly/checkly-go-sdk v1.13.0/go.mod h1:Pd6tBOggAe41NnCU5KwqA8JvD6J20/IctszT2E0AvHo=
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=


### PR DESCRIPTION
This PR adds support for the following new attributes in the `checkly_dashboard` resource:

- `show_header`
- `enable_incidents`
- `expand_checks`
- `show_check_run_links`
- `custom_css`
- `show_p95`
- `show_p99`

The default values for each are the same as the backend default values, meaning there's no change to previous behavior.

Additionally, the `header` attribute is now required, because the backend requires it. Because it was effectively already required, this is not a breaking change.

Extensive tests were created with Claude.

Closes #248.

## Affected Components
* [x] Resources
* [x] Test
* [ ] Docs
* [ ] Tooling
* [ ] Other

## Pre-Requisites
* [x] Terraform code is formatted with `terraform fmt`
* [x] Go code is formatted with `go fmt`
* [ ] `plan` & `apply` command of `demo/main.tf` file do not produce diffs

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #[issue-number]

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
