### PR TITLE
feat: add incident trigger support to all check resources

### DIFF
--- a/checkly/attribute_trigger_incident.go
+++ b/checkly/attribute_trigger_incident.go
@@ -1,0 +1,77 @@
+package checkly
+
+import (
+	checkly "github.com/checkly/checkly-go-sdk"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+var triggerIncidentAttributeSchema = &schema.Schema{
+	Description: "Set up HTTP basic authentication (username & password).",
+	Type:        schema.TypeSet,
+	MaxItems:    1,
+	Optional:    true,
+	Elem: &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"service_id": {
+				Description: "The status page service that this incident will be associated with.",
+				Type:        schema.TypeString,
+				Required:    true,
+			},
+			"severity": {
+				Description:  "The severity level of the incident. Possible values are `MINOR`, `MEDIUM`, `MAJOR`, and `CRITICAL`.",
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validateOneOf([]string{"MINOR", "MEDIUM", "MAJOR", "CRITICAL"}),
+			},
+			"name": {
+				Description: "The name of the incident.",
+				Type:        schema.TypeString,
+				Required:    true,
+			},
+			"description": {
+				Description: "A detailed description of the incident.",
+				Type:        schema.TypeString,
+				Required:    true,
+			},
+			"notify_subscribers": {
+				Description: "Whether to notify subscribers when the incident is triggered.",
+				Type:        schema.TypeBool,
+				Required:    true,
+			},
+		},
+	},
+}
+
+func triggerIncidentFromSet(s *schema.Set) *checkly.IncidentTrigger {
+	if s.Len() == 0 {
+		return nil
+	}
+
+	res := s.List()[0].(tfMap)
+
+	triggerIncident := &checkly.IncidentTrigger{
+		ServiceID:         res["service_id"].(string),
+		Severity:          checkly.IncidentSeverity(res["severity"].(string)),
+		Name:              res["name"].(string),
+		Description:       res["description"].(string),
+		NotifySubscribers: res["notify_subscribers"].(bool),
+	}
+
+	return triggerIncident
+}
+
+func setFromTriggerIncident(it *checkly.IncidentTrigger) []tfMap {
+	if it == nil {
+		return []tfMap{}
+	}
+
+	return []tfMap{
+		{
+			"service_id":         it.ServiceID,
+			"severity":           it.Severity,
+			"name":               it.Name,
+			"description":        it.Description,
+			"notify_subscribers": it.NotifySubscribers,
+		},
+	}
+}

--- a/checkly/resource_check.go
+++ b/checkly/resource_check.go
@@ -549,6 +549,7 @@ func resourceCheck() *schema.Resource {
 					},
 				},
 			},
+			"trigger_incident": triggerIncidentAttributeSchema,
 		},
 	}
 }
@@ -681,6 +682,7 @@ func resourceDataFromCheck(c *checkly.Check, d *schema.ResourceData) error {
 	d.Set("private_locations", c.PrivateLocations)
 	d.Set("alert_channel_subscription", c.AlertChannelSubscriptions)
 	d.Set("retry_strategy", setFromRetryStrategy(c.RetryStrategy))
+	d.Set("trigger_incident", setFromTriggerIncident(c.TriggerIncident))
 	d.SetId(d.Id())
 	return nil
 }
@@ -835,6 +837,7 @@ func checkFromResourceData(d *schema.ResourceData) (checkly.Check, error) {
 		GroupOrder:                d.Get("group_order").(int),
 		AlertChannelSubscriptions: alertChannelSubscriptionsFromSet(d.Get("alert_channel_subscription").([]interface{})),
 		RetryStrategy:             retryStrategyFromSet(d.Get("retry_strategy").(*schema.Set)),
+		TriggerIncident:           triggerIncidentFromSet(d.Get("trigger_incident").(*schema.Set)),
 	}
 
 	runtimeId := d.Get("runtime_id").(string)

--- a/checkly/resource_heartbeat_monitor.go
+++ b/checkly/resource_heartbeat_monitor.go
@@ -250,6 +250,7 @@ func resourceHeartbeatMonitor() *schema.Resource {
 					},
 				},
 			},
+			"trigger_incident": triggerIncidentAttributeSchema,
 		},
 	}
 }
@@ -324,6 +325,7 @@ func heartbeatMonitorFromResourceData(d *schema.ResourceData) (checkly.Heartbeat
 		AlertSettings:             alertSettingsFromSet(d.Get("alert_settings").([]interface{})),
 		UseGlobalAlertSettings:    d.Get("use_global_alert_settings").(bool),
 		AlertChannelSubscriptions: alertChannelSubscriptionsFromSet(d.Get("alert_channel_subscription").([]interface{})),
+		TriggerIncident:           triggerIncidentFromSet(d.Get("trigger_incident").(*schema.Set)),
 	}
 
 	// this will prevent subsequent apply from causing a tf config change in browser checks
@@ -398,6 +400,7 @@ func resourceDataFromHeartbeatMonitor(c *checkly.HeartbeatMonitor, d *schema.Res
 	}
 
 	d.Set("alert_channel_subscription", c.AlertChannelSubscriptions)
+	d.Set("trigger_incident", setFromTriggerIncident(c.TriggerIncident))
 	d.SetId(d.Id())
 
 	return nil

--- a/checkly/resource_tcp_monitor.go
+++ b/checkly/resource_tcp_monitor.go
@@ -362,6 +362,7 @@ func resourceTCPMonitor() *schema.Resource {
 					},
 				},
 			},
+			"trigger_incident": triggerIncidentAttributeSchema,
 		},
 	}
 }
@@ -463,6 +464,7 @@ func resourceDataFromTCPMonitor(c *checkly.TCPMonitor, d *schema.ResourceData) e
 	d.Set("private_locations", c.PrivateLocations)
 	d.Set("alert_channel_subscription", c.AlertChannelSubscriptions)
 	d.Set("retry_strategy", setFromRetryStrategy(c.RetryStrategy))
+	d.Set("trigger_incident", setFromTriggerIncident(c.TriggerIncident))
 	d.SetId(d.Id())
 	return nil
 }
@@ -495,6 +497,7 @@ func tcpCheckFromResourceData(d *schema.ResourceData) (checkly.TCPMonitor, error
 		GroupOrder:                d.Get("group_order").(int),
 		AlertChannelSubscriptions: alertChannelSubscriptionsFromSet(d.Get("alert_channel_subscription").([]interface{})),
 		RetryStrategy:             retryStrategyFromSet(d.Get("retry_strategy").(*schema.Set)),
+		TriggerIncident:           triggerIncidentFromSet(d.Get("trigger_incident").(*schema.Set)),
 	}
 
 	alertSettings := alertSettingsFromSet(d.Get("alert_settings").([]interface{}))

--- a/checkly/resource_url_monitor.go
+++ b/checkly/resource_url_monitor.go
@@ -347,6 +347,7 @@ func resourceURLMonitor() *schema.Resource {
 					},
 				},
 			},
+			"trigger_incident": triggerIncidentAttributeSchema,
 		},
 	}
 }
@@ -444,6 +445,7 @@ func resourceDataFromURLMonitor(c *checkly.URLMonitor, d *schema.ResourceData) e
 	d.Set("private_locations", c.PrivateLocations)
 	d.Set("alert_channel_subscription", c.AlertChannelSubscriptions)
 	d.Set("retry_strategy", setFromRetryStrategy(c.RetryStrategy))
+	d.Set("trigger_incident", setFromTriggerIncident(c.TriggerIncident))
 	d.SetId(d.Id())
 	return nil
 }
@@ -466,6 +468,7 @@ func urlMonitorFromResourceData(d *schema.ResourceData) (checkly.URLMonitor, err
 		GroupOrder:                d.Get("group_order").(int),
 		AlertChannelSubscriptions: alertChannelSubscriptionsFromSet(d.Get("alert_channel_subscription").([]interface{})),
 		RetryStrategy:             retryStrategyFromSet(d.Get("retry_strategy").(*schema.Set)),
+		TriggerIncident:           triggerIncidentFromSet(d.Get("trigger_incident").(*schema.Set)),
 	}
 
 	alertSettings := alertSettingsFromSet(d.Get("alert_settings").([]interface{}))

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.22
 
 require (
 	github.com/aws/aws-sdk-go v1.44.122 // indirect
-	github.com/checkly/checkly-go-sdk v1.13.0
+	github.com/checkly/checkly-go-sdk v1.14.0
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/google/go-cmp v0.6.0
 	github.com/gruntwork-io/terratest v0.41.16

--- a/go.sum
+++ b/go.sum
@@ -240,8 +240,8 @@ github.com/bmatcuk/doublestar/v4 v4.6.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTS
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/checkly/checkly-go-sdk v1.13.0 h1:LoQaj87fEcb7xTie7Z02rNfO1FqrwBti8wuBeINCGx0=
-github.com/checkly/checkly-go-sdk v1.13.0/go.mod h1:Pd6tBOggAe41NnCU5KwqA8JvD6J20/IctszT2E0AvHo=
+github.com/checkly/checkly-go-sdk v1.14.0 h1:m/9qRBHYMynnkRqxiufrFbvPszt7Bz0eouX1I379FM8=
+github.com/checkly/checkly-go-sdk v1.14.0/go.mod h1:Pd6tBOggAe41NnCU5KwqA8JvD6J20/IctszT2E0AvHo=
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=


### PR DESCRIPTION
This PR adds a new attribute called `trigger_incident` to all check resources.

It can be used as follows:

```terraform
resource "checkly_status_page_service" "web" {
  name = "Web"
}

resource "checkly_url_monitor" "test_url_monitor" {
  name      = "Web Monitor"
  activated = true
  frequency = 30
  locations = ["us-east-1", "eu-central-1"]

  request {
    url              = "https://welcome.checklyhq.com"
    follow_redirects = false
    assertion {
      source     = "STATUS_CODE"
      comparison = "EQUALS"
      target     = "200"
    }
  }

  trigger_incident {
    service_id         = checkly_status_page_service.web.id
    severity           = "MAJOR"
    name               = "Web offline"
    description        = "Web app is offline."
    notify_subscribers = true
  }
}
```

## Affected Components
* [x] Resources
* [x] Test
* [ ] Docs
* [ ] Tooling
* [ ] Other

## Pre-Requisites
* [x] Terraform code is formatted with `terraform fmt`
* [x] Go code is formatted with `go fmt`
* [ ] `plan` & `apply` command of `demo/main.tf` file do not produce diffs

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #[issue-number]

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
