### PR TITLE
feat: retry strategies can now be limited to network errors only [SIM-104]

### DIFF
--- a/checkly/resource_check_group_test.go
+++ b/checkly/resource_check_group_test.go
@@ -468,6 +468,65 @@ func TestAccCheckGroupWithSingleRetry(t *testing.T) {
 					"retry_strategy.0.same_region",
 					"true",
 				),
+				resource.TestCheckResourceAttr(
+					"checkly_check_group.test",
+					"retry_strategy.0.only_on.#",
+					"0",
+				),
+			),
+		},
+	})
+}
+
+func TestAccCheckGroupWithSingleRetryOnlyOnNetworkError(t *testing.T) {
+	accTestCase(t, []resource.TestStep{
+		{
+			Config: `
+				resource "checkly_check_group" "test" {
+					name        = "test-single-retry"
+					activated   = true
+					concurrency = 1
+					locations   = ["eu-central-1"]
+					retry_strategy {
+						type = "SINGLE_RETRY"
+
+						only_on {
+							network_error = true
+						}
+					}
+				}
+			`,
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr(
+					"checkly_check_group.test",
+					"retry_strategy.0.only_on.#",
+					"1",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_check_group.test",
+					"retry_strategy.0.only_on.0.network_error",
+					"true",
+				),
+			),
+		},
+		{
+			Config: `
+				resource "checkly_check_group" "test" {
+					name        = "test-single-retry"
+					activated   = true
+					concurrency = 1
+					locations   = ["eu-central-1"]
+					retry_strategy {
+						type = "SINGLE_RETRY"
+					}
+				}
+			`,
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr(
+					"checkly_check_group.test",
+					"retry_strategy.0.only_on.#",
+					"0",
+				),
 			),
 		},
 	})
@@ -513,6 +572,40 @@ func TestAccCheckGroupWithNoRetries(t *testing.T) {
 					"retry_strategy.0.same_region",
 					"false",
 				),
+				resource.TestCheckResourceAttr(
+					"checkly_check_group.test",
+					"retry_strategy.0.only_on.#",
+					"0",
+				),
+			),
+		},
+	})
+}
+
+func TestAccCheckGroupWithNoRetriesOnlyOnNetworkError(t *testing.T) {
+	accTestCase(t, []resource.TestStep{
+		{
+			Config: `
+				resource "checkly_check_group" "test" {
+					name        = "test-no-retries"
+					activated   = true
+					concurrency = 1
+					locations   = ["eu-central-1"]
+					retry_strategy {
+						type = "NO_RETRIES"
+
+						only_on {
+							network_error = true
+						}
+					}
+				}
+			`,
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr(
+					"checkly_check_group.test",
+					"retry_strategy.0.only_on.#",
+					"0",
+				),
 			),
 		},
 	})
@@ -554,6 +647,11 @@ func TestAccCheckGroupWithDefaultNoRetries(t *testing.T) {
 					"checkly_check_group.test",
 					"retry_strategy.0.same_region",
 					"false",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_check_group.test",
+					"retry_strategy.0.only_on.#",
+					"0",
 				),
 			),
 		},
@@ -604,6 +702,65 @@ func TestAccCheckGroupWithFixedRetry(t *testing.T) {
 					"retry_strategy.0.same_region",
 					"false",
 				),
+				resource.TestCheckResourceAttr(
+					"checkly_check_group.test",
+					"retry_strategy.0.only_on.#",
+					"0",
+				),
+			),
+		},
+	})
+}
+
+func TestAccCheckGroupWithFixedRetryOnlyOnNetworkError(t *testing.T) {
+	accTestCase(t, []resource.TestStep{
+		{
+			Config: `
+				resource "checkly_check_group" "test" {
+					name        = "test-fixed-retry"
+					activated   = true
+					concurrency = 1
+					locations   = ["eu-central-1"]
+					retry_strategy {
+						type = "FIXED"
+
+						only_on {
+							network_error = true
+						}
+					}
+				}
+			`,
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr(
+					"checkly_check_group.test",
+					"retry_strategy.0.only_on.#",
+					"1",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_check_group.test",
+					"retry_strategy.0.only_on.0.network_error",
+					"true",
+				),
+			),
+		},
+		{
+			Config: `
+				resource "checkly_check_group" "test" {
+					name        = "test-fixed-retry"
+					activated   = true
+					concurrency = 1
+					locations   = ["eu-central-1"]
+					retry_strategy {
+						type = "FIXED"
+					}
+				}
+			`,
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr(
+					"checkly_check_group.test",
+					"retry_strategy.0.only_on.#",
+					"0",
+				),
 			),
 		},
 	})
@@ -653,6 +810,65 @@ func TestAccCheckGroupWithExponentialRetry(t *testing.T) {
 					"retry_strategy.0.same_region",
 					"true",
 				),
+				resource.TestCheckResourceAttr(
+					"checkly_check_group.test",
+					"retry_strategy.0.only_on.#",
+					"0",
+				),
+			),
+		},
+	})
+}
+
+func TestAccCheckGroupWithExponentialRetryOnlyOnNetworkError(t *testing.T) {
+	accTestCase(t, []resource.TestStep{
+		{
+			Config: `
+				resource "checkly_check_group" "test" {
+					name        = "test-exponential-retry"
+					activated   = true
+					concurrency = 1
+					locations   = ["eu-central-1"]
+					retry_strategy {
+						type = "EXPONENTIAL"
+
+						only_on {
+							network_error = true
+						}
+					}
+				}
+			`,
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr(
+					"checkly_check_group.test",
+					"retry_strategy.0.only_on.#",
+					"1",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_check_group.test",
+					"retry_strategy.0.only_on.0.network_error",
+					"true",
+				),
+			),
+		},
+		{
+			Config: `
+				resource "checkly_check_group" "test" {
+					name        = "test-exponential-retry"
+					activated   = true
+					concurrency = 1
+					locations   = ["eu-central-1"]
+					retry_strategy {
+						type = "EXPONENTIAL"
+					}
+				}
+			`,
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr(
+					"checkly_check_group.test",
+					"retry_strategy.0.only_on.#",
+					"0",
+				),
 			),
 		},
 	})
@@ -701,6 +917,65 @@ func TestAccCheckGroupWithLinearRetry(t *testing.T) {
 					"checkly_check_group.test",
 					"retry_strategy.0.same_region",
 					"false",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_check_group.test",
+					"retry_strategy.0.only_on.#",
+					"0",
+				),
+			),
+		},
+	})
+}
+
+func TestAccCheckGroupWithLinearRetryOnlyOnNetworkError(t *testing.T) {
+	accTestCase(t, []resource.TestStep{
+		{
+			Config: `
+				resource "checkly_check_group" "test" {
+					name        = "test-linear-retry"
+					activated   = true
+					concurrency = 1
+					locations   = ["eu-central-1"]
+					retry_strategy {
+						type = "LINEAR"
+
+						only_on {
+							network_error = true
+						}
+					}
+				}
+			`,
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr(
+					"checkly_check_group.test",
+					"retry_strategy.0.only_on.#",
+					"1",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_check_group.test",
+					"retry_strategy.0.only_on.0.network_error",
+					"true",
+				),
+			),
+		},
+		{
+			Config: `
+				resource "checkly_check_group" "test" {
+					name        = "test-linear-retry"
+					activated   = true
+					concurrency = 1
+					locations   = ["eu-central-1"]
+					retry_strategy {
+						type = "LINEAR"
+					}
+				}
+			`,
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr(
+					"checkly_check_group.test",
+					"retry_strategy.0.only_on.#",
+					"0",
 				),
 			),
 		},

--- a/checkly/resource_check_test.go
+++ b/checkly/resource_check_test.go
@@ -714,6 +714,75 @@ func TestAccCheckWithSingleRetry(t *testing.T) {
 					"retry_strategy.0.same_region",
 					"true",
 				),
+				resource.TestCheckResourceAttr(
+					"checkly_check.test",
+					"retry_strategy.0.only_on.#",
+					"0",
+				),
+			),
+		},
+	})
+}
+
+func TestAccCheckWithSingleRetryOnlyOnNetworkError(t *testing.T) {
+	accTestCase(t, []resource.TestStep{
+		{
+			Config: `
+				resource "checkly_check" "test" {
+					name      = "test-single-retry"
+					type      = "API"
+					activated = true
+					frequency = 60
+					locations = ["eu-central-1"]
+					request {
+						method = "GET"
+						url    = "https://api.checklyhq.com/public-stats"
+					}
+					retry_strategy {
+						type = "SINGLE_RETRY"
+
+						only_on {
+							network_error = true
+						}
+					}
+				}
+			`,
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr(
+					"checkly_check.test",
+					"retry_strategy.0.only_on.#",
+					"1",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_check.test",
+					"retry_strategy.0.only_on.0.network_error",
+					"true",
+				),
+			),
+		},
+		{
+			Config: `
+				resource "checkly_check" "test" {
+					name      = "test-single-retry"
+					type      = "API"
+					activated = true
+					frequency = 60
+					locations = ["eu-central-1"]
+					request {
+						method = "GET"
+						url    = "https://api.checklyhq.com/public-stats"
+					}
+					retry_strategy {
+						type = "SINGLE_RETRY"
+					}
+				}
+			`,
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr(
+					"checkly_check.test",
+					"retry_strategy.0.only_on.#",
+					"0",
+				),
 			),
 		},
 	})
@@ -763,6 +832,45 @@ func TestAccCheckWithNoRetries(t *testing.T) {
 					"checkly_check.test",
 					"retry_strategy.0.same_region",
 					"false",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_check.test",
+					"retry_strategy.0.only_on.#",
+					"0",
+				),
+			),
+		},
+	})
+}
+
+func TestAccCheckWithNoRetriesOnlyOnNetworkError(t *testing.T) {
+	accTestCase(t, []resource.TestStep{
+		{
+			Config: `
+				resource "checkly_check" "test" {
+					name      = "test-no-retries"
+					type      = "API"
+					activated = true
+					frequency = 60
+					locations = ["eu-central-1"]
+					request {
+						method = "GET"
+						url    = "https://api.checklyhq.com/public-stats"
+					}
+					retry_strategy {
+						type = "NO_RETRIES"
+
+						only_on {
+							network_error = true
+						}
+					}
+				}
+			`,
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr(
+					"checkly_check.test",
+					"retry_strategy.0.only_on.#",
+					"0",
 				),
 			),
 		},
@@ -865,6 +973,75 @@ func TestAccCheckWithFixedRetry(t *testing.T) {
 					"retry_strategy.0.same_region",
 					"false",
 				),
+				resource.TestCheckResourceAttr(
+					"checkly_check.test",
+					"retry_strategy.0.only_on.#",
+					"0",
+				),
+			),
+		},
+	})
+}
+
+func TestAccCheckWithFixedRetryOnlyOnNetworkError(t *testing.T) {
+	accTestCase(t, []resource.TestStep{
+		{
+			Config: `
+				resource "checkly_check" "test" {
+					name      = "test-fixed-retry"
+					type      = "API"
+					activated = true
+					frequency = 60
+					locations = ["eu-central-1"]
+					request {
+						method = "GET"
+						url    = "https://api.checklyhq.com/public-stats"
+					}
+					retry_strategy {
+						type = "FIXED"
+
+						only_on {
+							network_error = true
+						}
+					}
+				}
+			`,
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr(
+					"checkly_check.test",
+					"retry_strategy.0.only_on.#",
+					"1",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_check.test",
+					"retry_strategy.0.only_on.0.network_error",
+					"true",
+				),
+			),
+		},
+		{
+			Config: `
+				resource "checkly_check" "test" {
+					name      = "test-fixed-retry"
+					type      = "API"
+					activated = true
+					frequency = 60
+					locations = ["eu-central-1"]
+					request {
+						method = "GET"
+						url    = "https://api.checklyhq.com/public-stats"
+					}
+					retry_strategy {
+						type = "FIXED"
+					}
+				}
+			`,
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr(
+					"checkly_check.test",
+					"retry_strategy.0.only_on.#",
+					"0",
+				),
 			),
 		},
 	})
@@ -915,6 +1092,69 @@ func TestAccCheckWithExponentialRetry(t *testing.T) {
 					"checkly_check.test",
 					"retry_strategy.0.same_region",
 					"true",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_check.test",
+					"retry_strategy.0.only_on.#",
+					"0",
+				),
+			),
+		},
+	})
+}
+
+func TestAccCheckWithExponentialRetryOnlyOnNetworkError(t *testing.T) {
+	accTestCase(t, []resource.TestStep{
+		{
+			Config: `
+				resource "checkly_check" "test" {
+					name      = "test-exponential-retry"
+					type      = "BROWSER"
+					activated = true
+					frequency = 720
+					locations = ["eu-central-1"]
+					script    = "console.log('test')"
+					retry_strategy {
+						type = "EXPONENTIAL"
+
+						only_on {
+							network_error = true
+						}
+					}
+				}
+			`,
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr(
+					"checkly_check.test",
+					"retry_strategy.0.only_on.#",
+					"1",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_check.test",
+					"retry_strategy.0.only_on.0.network_error",
+					"true",
+				),
+			),
+		},
+		{
+			Config: `
+				resource "checkly_check" "test" {
+					name      = "test-exponential-retry"
+					type      = "BROWSER"
+					activated = true
+					frequency = 720
+					locations = ["eu-central-1"]
+					script    = "console.log('test')"
+					retry_strategy {
+						type = "EXPONENTIAL"
+					}
+				}
+			`,
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr(
+					"checkly_check.test",
+					"retry_strategy.0.only_on.#",
+					"0",
 				),
 			),
 		},
@@ -967,6 +1207,71 @@ func TestAccCheckWithLinearRetry(t *testing.T) {
 					"checkly_check.test",
 					"retry_strategy.0.same_region",
 					"false",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_check.test",
+					"retry_strategy.0.only_on.#",
+					"0",
+				),
+			),
+		},
+	})
+}
+
+func TestAccCheckWithLinearRetryOnlyOnNetworkError(t *testing.T) {
+	accTestCase(t, []resource.TestStep{
+		{
+			Config: `
+				resource "checkly_check" "test" {
+					name       = "test-linear-retry"
+					type       = "MULTI_STEP"
+					activated  = true
+					frequency  = 720
+					locations  = ["eu-central-1"]
+					runtime_id = "2023.09"
+					script     = "console.log('test')"
+					retry_strategy {
+						type = "LINEAR"
+
+						only_on {
+							network_error = true
+						}
+					}
+				}
+			`,
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr(
+					"checkly_check.test",
+					"retry_strategy.0.only_on.#",
+					"1",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_check.test",
+					"retry_strategy.0.only_on.0.network_error",
+					"true",
+				),
+			),
+		},
+		{
+			Config: `
+				resource "checkly_check" "test" {
+					name       = "test-linear-retry"
+					type       = "MULTI_STEP"
+					activated  = true
+					frequency  = 720
+					locations  = ["eu-central-1"]
+					runtime_id = "2023.09"
+					script     = "console.log('test')"
+					retry_strategy {
+						type = "LINEAR"
+					}
+				}
+			`,
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr(
+					"checkly_check.test",
+					"retry_strategy.0.only_on.#",
+					"0",
 				),
 			),
 		},

--- a/checkly/resource_tcp_monitor_test.go
+++ b/checkly/resource_tcp_monitor_test.go
@@ -385,6 +385,73 @@ func TestAccTCPMonitorWithSingleRetry(t *testing.T) {
 					"retry_strategy.0.same_region",
 					"true",
 				),
+				resource.TestCheckResourceAttr(
+					"checkly_tcp_monitor.test",
+					"retry_strategy.0.only_on.#",
+					"0",
+				),
+			),
+		},
+	})
+}
+
+func TestAccTCPMonitorWithSingleRetryOnlyOnNetworkError(t *testing.T) {
+	accTestCase(t, []resource.TestStep{
+		{
+			Config: `
+				resource "checkly_tcp_monitor" "test" {
+					name      = "test-single-retry"
+					activated = true
+					frequency = 60
+					locations = ["eu-central-1"]
+					request {
+						port     = 443
+						hostname = "checkly.com"
+					}
+					retry_strategy {
+						type = "SINGLE_RETRY"
+
+						only_on {
+							network_error = true
+						}
+					}
+				}
+			`,
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr(
+					"checkly_tcp_monitor.test",
+					"retry_strategy.0.only_on.#",
+					"1",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_tcp_monitor.test",
+					"retry_strategy.0.only_on.0.network_error",
+					"true",
+				),
+			),
+		},
+		{
+			Config: `
+				resource "checkly_tcp_monitor" "test" {
+					name      = "test-single-retry"
+					activated = true
+					frequency = 60
+					locations = ["eu-central-1"]
+					request {
+						port     = 443
+						hostname = "checkly.com"
+					}
+					retry_strategy {
+						type = "SINGLE_RETRY"
+					}
+				}
+			`,
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr(
+					"checkly_tcp_monitor.test",
+					"retry_strategy.0.only_on.#",
+					"0",
+				),
 			),
 		},
 	})
@@ -434,6 +501,44 @@ func TestAccTCPMonitorWithNoRetries(t *testing.T) {
 					"retry_strategy.0.same_region",
 					"false",
 				),
+				resource.TestCheckResourceAttr(
+					"checkly_tcp_monitor.test",
+					"retry_strategy.0.only_on.#",
+					"0",
+				),
+			),
+		},
+	})
+}
+
+func TestAccTCPMonitorWithNoRetriesOnlyOnNetworkError(t *testing.T) {
+	accTestCase(t, []resource.TestStep{
+		{
+			Config: `
+				resource "checkly_tcp_monitor" "test" {
+					name      = "test-no-retries"
+					activated = true
+					frequency = 60
+					locations = ["eu-central-1"]
+					request {
+						port     = 443
+						hostname = "checkly.com"
+					}
+					retry_strategy {
+						type = "NO_RETRIES"
+
+						only_on {
+							network_error = true
+						}
+					}
+				}
+			`,
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr(
+					"checkly_tcp_monitor.test",
+					"retry_strategy.0.only_on.#",
+					"0",
+				),
 			),
 		},
 	})
@@ -479,6 +584,11 @@ func TestAccTCPMonitorWithDefaultNoRetries(t *testing.T) {
 					"checkly_tcp_monitor.test",
 					"retry_strategy.0.same_region",
 					"false",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_tcp_monitor.test",
+					"retry_strategy.0.only_on.#",
+					"0",
 				),
 			),
 		},
@@ -533,6 +643,73 @@ func TestAccTCPMonitorWithFixedRetry(t *testing.T) {
 					"retry_strategy.0.same_region",
 					"false",
 				),
+				resource.TestCheckResourceAttr(
+					"checkly_tcp_monitor.test",
+					"retry_strategy.0.only_on.#",
+					"0",
+				),
+			),
+		},
+	})
+}
+
+func TestAccTCPMonitorWithFixedRetryOnlyOnNetworkError(t *testing.T) {
+	accTestCase(t, []resource.TestStep{
+		{
+			Config: `
+				resource "checkly_tcp_monitor" "test" {
+					name      = "test-fixed-retry"
+					activated = true
+					frequency = 60
+					locations = ["eu-central-1"]
+					request {
+						port     = 443
+						hostname = "checkly.com"
+					}
+					retry_strategy {
+						type = "FIXED"
+
+						only_on {
+							network_error = true
+						}
+					}
+				}
+			`,
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr(
+					"checkly_tcp_monitor.test",
+					"retry_strategy.0.only_on.#",
+					"1",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_tcp_monitor.test",
+					"retry_strategy.0.only_on.0.network_error",
+					"true",
+				),
+			),
+		},
+		{
+			Config: `
+				resource "checkly_tcp_monitor" "test" {
+					name      = "test-fixed-retry"
+					activated = true
+					frequency = 60
+					locations = ["eu-central-1"]
+					request {
+						port     = 443
+						hostname = "checkly.com"
+					}
+					retry_strategy {
+						type = "FIXED"
+					}
+				}
+			`,
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr(
+					"checkly_tcp_monitor.test",
+					"retry_strategy.0.only_on.#",
+					"0",
+				),
 			),
 		},
 	})
@@ -586,6 +763,73 @@ func TestAccTCPMonitorWithExponentialRetry(t *testing.T) {
 					"retry_strategy.0.same_region",
 					"true",
 				),
+				resource.TestCheckResourceAttr(
+					"checkly_tcp_monitor.test",
+					"retry_strategy.0.only_on.#",
+					"0",
+				),
+			),
+		},
+	})
+}
+
+func TestAccTCPMonitorWithExponentialRetryOnlyOnNetworkError(t *testing.T) {
+	accTestCase(t, []resource.TestStep{
+		{
+			Config: `
+				resource "checkly_tcp_monitor" "test" {
+					name      = "test-exponential-retry"
+					activated = true
+					frequency = 720
+					locations = ["eu-central-1"]
+					request {
+						port     = 443
+						hostname = "checkly.com"
+					}
+					retry_strategy {
+						type = "EXPONENTIAL"
+
+						only_on {
+							network_error = true
+						}
+					}
+				}
+			`,
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr(
+					"checkly_tcp_monitor.test",
+					"retry_strategy.0.only_on.#",
+					"1",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_tcp_monitor.test",
+					"retry_strategy.0.only_on.0.network_error",
+					"true",
+				),
+			),
+		},
+		{
+			Config: `
+				resource "checkly_tcp_monitor" "test" {
+					name      = "test-exponential-retry"
+					activated = true
+					frequency = 720
+					locations = ["eu-central-1"]
+					request {
+						port     = 443
+						hostname = "checkly.com"
+					}
+					retry_strategy {
+						type = "EXPONENTIAL"
+					}
+				}
+			`,
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr(
+					"checkly_tcp_monitor.test",
+					"retry_strategy.0.only_on.#",
+					"0",
+				),
 			),
 		},
 	})
@@ -638,6 +882,73 @@ func TestAccTCPMonitorWithLinearRetry(t *testing.T) {
 					"checkly_tcp_monitor.test",
 					"retry_strategy.0.same_region",
 					"false",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_tcp_monitor.test",
+					"retry_strategy.0.only_on.#",
+					"0",
+				),
+			),
+		},
+	})
+}
+
+func TestAccTCPMonitorWithLinearRetryOnlyOnNetworkError(t *testing.T) {
+	accTestCase(t, []resource.TestStep{
+		{
+			Config: `
+				resource "checkly_tcp_monitor" "test" {
+					name      = "test-linear-retry"
+					activated = true
+					frequency = 720
+					locations = ["eu-central-1"]
+					request {
+						port     = 443
+						hostname = "checkly.com"
+					}
+					retry_strategy {
+						type = "LINEAR"
+
+						only_on {
+							network_error = true
+						}
+					}
+				}
+			`,
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr(
+					"checkly_tcp_monitor.test",
+					"retry_strategy.0.only_on.#",
+					"1",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_tcp_monitor.test",
+					"retry_strategy.0.only_on.0.network_error",
+					"true",
+				),
+			),
+		},
+		{
+			Config: `
+				resource "checkly_tcp_monitor" "test" {
+					name      = "test-linear-retry"
+					activated = true
+					frequency = 720
+					locations = ["eu-central-1"]
+					request {
+						port     = 443
+						hostname = "checkly.com"
+					}
+					retry_strategy {
+						type = "LINEAR"
+					}
+				}
+			`,
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr(
+					"checkly_tcp_monitor.test",
+					"retry_strategy.0.only_on.#",
+					"0",
 				),
 			),
 		},

--- a/checkly/resource_url_monitor_test.go
+++ b/checkly/resource_url_monitor_test.go
@@ -397,6 +397,72 @@ func TestAccURLMonitorWithSingleRetry(t *testing.T) {
 					"retry_strategy.0.same_region",
 					"true",
 				),
+				resource.TestCheckResourceAttr(
+					"checkly_url_monitor.test",
+					"retry_strategy.0.only_on.#",
+					"0",
+				),
+			),
+		},
+	})
+
+}
+
+func TestAccURLMonitorWithSingleRetryOnlyOnNetworkError(t *testing.T) {
+	accTestCase(t, []resource.TestStep{
+		{
+			Config: `
+				resource "checkly_url_monitor" "test" {
+					name      = "test-single-retry"
+					activated = true
+					frequency = 60
+					locations = ["eu-central-1"]
+					request {
+						url = "https://checkly.com"
+					}
+					retry_strategy {
+						type = "SINGLE_RETRY"
+
+						only_on {
+							network_error = true
+						}
+					}
+				}
+			`,
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr(
+					"checkly_url_monitor.test",
+					"retry_strategy.0.only_on.#",
+					"1",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_url_monitor.test",
+					"retry_strategy.0.only_on.0.network_error",
+					"true",
+				),
+			),
+		},
+		{
+			Config: `
+				resource "checkly_url_monitor" "test" {
+					name      = "test-single-retry"
+					activated = true
+					frequency = 60
+					locations = ["eu-central-1"]
+					request {
+						url = "https://checkly.com"
+					}
+					retry_strategy {
+						type = "SINGLE_RETRY"
+					}
+				}
+			`,
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr(
+					"checkly_url_monitor.test",
+					"retry_strategy.0.only_on.#",
+					"0",
+				),
 			),
 		},
 	})
@@ -445,6 +511,43 @@ func TestAccURLMonitorWithNoRetries(t *testing.T) {
 					"retry_strategy.0.same_region",
 					"false",
 				),
+				resource.TestCheckResourceAttr(
+					"checkly_url_monitor.test",
+					"retry_strategy.0.only_on.#",
+					"0",
+				),
+			),
+		},
+	})
+}
+
+func TestAccURLMonitorWithNoRetriesOnlyOnNetworkError(t *testing.T) {
+	accTestCase(t, []resource.TestStep{
+		{
+			Config: `
+				resource "checkly_url_monitor" "test" {
+					name      = "test-no-retries"
+					activated = true
+					frequency = 60
+					locations = ["eu-central-1"]
+					request {
+						url = "https://checkly.com"
+					}
+					retry_strategy {
+						type = "NO_RETRIES"
+
+						only_on {
+							network_error = true
+						}
+					}
+				}
+			`,
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr(
+					"checkly_url_monitor.test",
+					"retry_strategy.0.only_on.#",
+					"0",
+				),
 			),
 		},
 	})
@@ -489,6 +592,11 @@ func TestAccURLMonitorWithDefaultNoRetries(t *testing.T) {
 					"checkly_url_monitor.test",
 					"retry_strategy.0.same_region",
 					"false",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_url_monitor.test",
+					"retry_strategy.0.only_on.#",
+					"0",
 				),
 			),
 		},
@@ -542,6 +650,71 @@ func TestAccURLMonitorWithFixedRetry(t *testing.T) {
 					"retry_strategy.0.same_region",
 					"false",
 				),
+				resource.TestCheckResourceAttr(
+					"checkly_url_monitor.test",
+					"retry_strategy.0.only_on.#",
+					"0",
+				),
+			),
+		},
+	})
+}
+
+func TestAccURLMonitorWithFixedRetryOnlyOnNetworkError(t *testing.T) {
+	accTestCase(t, []resource.TestStep{
+		{
+			Config: `
+				resource "checkly_url_monitor" "test" {
+					name      = "test-fixed-retry"
+					activated = true
+					frequency = 60
+					locations = ["eu-central-1"]
+					request {
+						url = "https://checkly.com"
+					}
+					retry_strategy {
+						type = "FIXED"
+
+						only_on {
+							network_error = true
+						}
+					}
+				}
+			`,
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr(
+					"checkly_url_monitor.test",
+					"retry_strategy.0.only_on.#",
+					"1",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_url_monitor.test",
+					"retry_strategy.0.only_on.0.network_error",
+					"true",
+				),
+			),
+		},
+		{
+			Config: `
+				resource "checkly_url_monitor" "test" {
+					name      = "test-fixed-retry"
+					activated = true
+					frequency = 60
+					locations = ["eu-central-1"]
+					request {
+						url = "https://checkly.com"
+					}
+					retry_strategy {
+						type = "FIXED"
+					}
+				}
+			`,
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr(
+					"checkly_url_monitor.test",
+					"retry_strategy.0.only_on.#",
+					"0",
+				),
 			),
 		},
 	})
@@ -594,6 +767,71 @@ func TestAccURLMonitorWithExponentialRetry(t *testing.T) {
 					"retry_strategy.0.same_region",
 					"true",
 				),
+				resource.TestCheckResourceAttr(
+					"checkly_url_monitor.test",
+					"retry_strategy.0.only_on.#",
+					"0",
+				),
+			),
+		},
+	})
+}
+
+func TestAccURLMonitorWithExponentialRetryOnlyOnNetworkError(t *testing.T) {
+	accTestCase(t, []resource.TestStep{
+		{
+			Config: `
+				resource "checkly_url_monitor" "test" {
+					name      = "test-exponential-retry"
+					activated = true
+					frequency = 720
+					locations = ["eu-central-1"]
+					request {
+						url = "https://checkly.com"
+					}
+					retry_strategy {
+						type = "EXPONENTIAL"
+
+						only_on {
+							network_error = true
+						}
+					}
+				}
+			`,
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr(
+					"checkly_url_monitor.test",
+					"retry_strategy.0.only_on.#",
+					"1",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_url_monitor.test",
+					"retry_strategy.0.only_on.0.network_error",
+					"true",
+				),
+			),
+		},
+		{
+			Config: `
+				resource "checkly_url_monitor" "test" {
+					name      = "test-exponential-retry"
+					activated = true
+					frequency = 720
+					locations = ["eu-central-1"]
+					request {
+						url = "https://checkly.com"
+					}
+					retry_strategy {
+						type = "EXPONENTIAL"
+					}
+				}
+			`,
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr(
+					"checkly_url_monitor.test",
+					"retry_strategy.0.only_on.#",
+					"0",
+				),
 			),
 		},
 	})
@@ -645,6 +883,71 @@ func TestAccURLMonitorWithLinearRetry(t *testing.T) {
 					"checkly_url_monitor.test",
 					"retry_strategy.0.same_region",
 					"false",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_url_monitor.test",
+					"retry_strategy.0.only_on.#",
+					"0",
+				),
+			),
+		},
+	})
+}
+
+func TestAccURLMonitorWithLinearRetryOnlyOnNetworkError(t *testing.T) {
+	accTestCase(t, []resource.TestStep{
+		{
+			Config: `
+				resource "checkly_url_monitor" "test" {
+					name      = "test-linear-retry"
+					activated = true
+					frequency = 720
+					locations = ["eu-central-1"]
+					request {
+						url = "https://checkly.com"
+					}
+					retry_strategy {
+						type = "LINEAR"
+
+						only_on {
+							network_error = true
+						}
+					}
+				}
+			`,
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr(
+					"checkly_url_monitor.test",
+					"retry_strategy.0.only_on.#",
+					"1",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_url_monitor.test",
+					"retry_strategy.0.only_on.0.network_error",
+					"true",
+				),
+			),
+		},
+		{
+			Config: `
+				resource "checkly_url_monitor" "test" {
+					name      = "test-linear-retry"
+					activated = true
+					frequency = 720
+					locations = ["eu-central-1"]
+					request {
+						url = "https://checkly.com"
+					}
+					retry_strategy {
+						type = "LINEAR"
+					}
+				}
+			`,
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr(
+					"checkly_url_monitor.test",
+					"retry_strategy.0.only_on.#",
+					"0",
 				),
 			),
 		},

--- a/docs/resources/check.md
+++ b/docs/resources/check.md
@@ -364,7 +364,16 @@ Optional:
 - `base_backoff_seconds` (Number) The number of seconds to wait before the first retry attempt. (Default `60`).
 - `max_duration_seconds` (Number) The total amount of time to continue retrying the check/monitor (maximum 600 seconds). Available when `type` is `FIXED`, `LINEAR`, or `EXPONENTIAL`. (Default `600`).
 - `max_retries` (Number) The maximum number of times to retry the check/monitor. Value must be between `1` and `10`. Available when `type` is `FIXED`, `LINEAR`, or `EXPONENTIAL`. (Default `2`).
+- `only_on` (Block List, Max: 1) Apply the retry strategy only if the defined conditions match. (see [below for nested schema](#nestedblock--retry_strategy--only_on))
 - `same_region` (Boolean) Whether retries should be run in the same region as the initial check/monitor run. (Default `true`).
+
+<a id="nestedblock--retry_strategy--only_on"></a>
+### Nested Schema for `retry_strategy.only_on`
+
+Optional:
+
+- `network_error` (Boolean) When `true`, retry only if the cause of the failure is a network error. (Default `false`).
+
 
 
 <a id="nestedblock--trigger_incident"></a>

--- a/docs/resources/check_group.md
+++ b/docs/resources/check_group.md
@@ -297,4 +297,12 @@ Optional:
 - `base_backoff_seconds` (Number) The number of seconds to wait before the first retry attempt. (Default `60`).
 - `max_duration_seconds` (Number) The total amount of time to continue retrying the check/monitor (maximum 600 seconds). Available when `type` is `FIXED`, `LINEAR`, or `EXPONENTIAL`. (Default `600`).
 - `max_retries` (Number) The maximum number of times to retry the check/monitor. Value must be between `1` and `10`. Available when `type` is `FIXED`, `LINEAR`, or `EXPONENTIAL`. (Default `2`).
+- `only_on` (Block List, Max: 1) Apply the retry strategy only if the defined conditions match. (see [below for nested schema](#nestedblock--retry_strategy--only_on))
 - `same_region` (Boolean) Whether retries should be run in the same region as the initial check/monitor run. (Default `true`).
+
+<a id="nestedblock--retry_strategy--only_on"></a>
+### Nested Schema for `retry_strategy.only_on`
+
+Optional:
+
+- `network_error` (Boolean) When `true`, retry only if the cause of the failure is a network error. (Default `false`).

--- a/docs/resources/tcp_check.md
+++ b/docs/resources/tcp_check.md
@@ -224,7 +224,16 @@ Optional:
 - `base_backoff_seconds` (Number) The number of seconds to wait before the first retry attempt. (Default `60`).
 - `max_duration_seconds` (Number) The total amount of time to continue retrying the check/monitor (maximum 600 seconds). Available when `type` is `FIXED`, `LINEAR`, or `EXPONENTIAL`. (Default `600`).
 - `max_retries` (Number) The maximum number of times to retry the check/monitor. Value must be between `1` and `10`. Available when `type` is `FIXED`, `LINEAR`, or `EXPONENTIAL`. (Default `2`).
+- `only_on` (Block List, Max: 1) Apply the retry strategy only if the defined conditions match. (see [below for nested schema](#nestedblock--retry_strategy--only_on))
 - `same_region` (Boolean) Whether retries should be run in the same region as the initial check/monitor run. (Default `true`).
+
+<a id="nestedblock--retry_strategy--only_on"></a>
+### Nested Schema for `retry_strategy.only_on`
+
+Optional:
+
+- `network_error` (Boolean) When `true`, retry only if the cause of the failure is a network error. (Default `false`).
+
 
 
 <a id="nestedblock--trigger_incident"></a>

--- a/docs/resources/tcp_monitor.md
+++ b/docs/resources/tcp_monitor.md
@@ -218,7 +218,16 @@ Optional:
 - `base_backoff_seconds` (Number) The number of seconds to wait before the first retry attempt. (Default `60`).
 - `max_duration_seconds` (Number) The total amount of time to continue retrying the check/monitor (maximum 600 seconds). Available when `type` is `FIXED`, `LINEAR`, or `EXPONENTIAL`. (Default `600`).
 - `max_retries` (Number) The maximum number of times to retry the check/monitor. Value must be between `1` and `10`. Available when `type` is `FIXED`, `LINEAR`, or `EXPONENTIAL`. (Default `2`).
+- `only_on` (Block List, Max: 1) Apply the retry strategy only if the defined conditions match. (see [below for nested schema](#nestedblock--retry_strategy--only_on))
 - `same_region` (Boolean) Whether retries should be run in the same region as the initial check/monitor run. (Default `true`).
+
+<a id="nestedblock--retry_strategy--only_on"></a>
+### Nested Schema for `retry_strategy.only_on`
+
+Optional:
+
+- `network_error` (Boolean) When `true`, retry only if the cause of the failure is a network error. (Default `false`).
+
 
 
 <a id="nestedblock--trigger_incident"></a>

--- a/docs/resources/url_monitor.md
+++ b/docs/resources/url_monitor.md
@@ -167,7 +167,16 @@ Optional:
 - `base_backoff_seconds` (Number) The number of seconds to wait before the first retry attempt. (Default `60`).
 - `max_duration_seconds` (Number) The total amount of time to continue retrying the check/monitor (maximum 600 seconds). Available when `type` is `FIXED`, `LINEAR`, or `EXPONENTIAL`. (Default `600`).
 - `max_retries` (Number) The maximum number of times to retry the check/monitor. Value must be between `1` and `10`. Available when `type` is `FIXED`, `LINEAR`, or `EXPONENTIAL`. (Default `2`).
+- `only_on` (Block List, Max: 1) Apply the retry strategy only if the defined conditions match. (see [below for nested schema](#nestedblock--retry_strategy--only_on))
 - `same_region` (Boolean) Whether retries should be run in the same region as the initial check/monitor run. (Default `true`).
+
+<a id="nestedblock--retry_strategy--only_on"></a>
+### Nested Schema for `retry_strategy.only_on`
+
+Optional:
+
+- `network_error` (Boolean) When `true`, retry only if the cause of the failure is a network error. (Default `false`).
+
 
 
 <a id="nestedblock--trigger_incident"></a>


### PR DESCRIPTION
This PR adds a new `only_on` attribute to retry strategies, which can currently be used to limit retries to network errors.

Example usage:

```
retry_strategy {
	type = "SINGLE_RETRY"

	only_on {
		network_error = true
	}
}
```

## Affected Components
* [x] Resources
* [x] Test
* [x] Docs
* [ ] Tooling
* [ ] Other

## Pre-Requisites
* [x] Terraform code is formatted with `terraform fmt`
* [x] Go code is formatted with `go fmt`
* [ ] `plan` & `apply` command of `demo/main.tf` file do not produce diffs

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #[issue-number]

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
