### PR TITLE
fix: make it possible to unassign a check/monitor from a group

### DIFF
--- a/checkly/resource_check_test.go
+++ b/checkly/resource_check_test.go
@@ -1503,3 +1503,173 @@ const apiCheck_withEmptyBasicAuth = `
 	}
   }
 `
+
+func TestAccCheckGroupAssignment(t *testing.T) {
+	accTestCase(t, []resource.TestStep{
+		{
+			Config: `
+				resource "checkly_check_group" "test1" {
+					name        = "test-group-assignment"
+					activated   = true
+					concurrency = 1
+					locations   = ["eu-central-1"]
+				}
+
+				resource "checkly_check_group" "test2" {
+					name        = "test-group-assignment"
+					activated   = true
+					concurrency = 1
+					locations   = ["eu-central-1"]
+				}
+
+				resource "checkly_check" "test1" {
+					name      = "test-group-assignment"
+					type      = "API"
+					activated = true
+					frequency = 60
+					locations = ["eu-central-1"]
+					group_id  = checkly_check_group.test1.id
+					request {
+						method = "GET"
+						url    = "https://welcome.checklyhq.com"
+					}
+				}
+
+				resource "checkly_check" "test2" {
+					name      = "test-group-assignment"
+					type      = "API"
+					activated = true
+					frequency = 60
+					locations = ["eu-central-1"]
+					request {
+						method = "GET"
+						url    = "https://welcome.checklyhq.com"
+					}
+				}
+			`,
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttrPair(
+					"checkly_check.test1",
+					"group_id",
+					"checkly_check_group.test1",
+					"id",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_check.test2",
+					"group_id",
+					"0",
+				),
+			),
+		},
+		{
+			Config: `
+				resource "checkly_check_group" "test1" {
+					name        = "test-group-assignment"
+					activated   = true
+					concurrency = 1
+					locations   = ["eu-central-1"]
+				}
+
+				resource "checkly_check_group" "test2" {
+					name        = "test-group-assignment"
+					activated   = true
+					concurrency = 1
+					locations   = ["eu-central-1"]
+				}
+
+				resource "checkly_check" "test1" {
+					name      = "test-group-assignment"
+					type      = "API"
+					activated = true
+					frequency = 60
+					locations = ["eu-central-1"]
+					group_id  = checkly_check_group.test2.id
+					request {
+						method = "GET"
+						url    = "https://welcome.checklyhq.com"
+					}
+				}
+
+				resource "checkly_check" "test2" {
+					name      = "test-group-assignment"
+					type      = "API"
+					activated = true
+					frequency = 60
+					locations = ["eu-central-1"]
+					group_id  = checkly_check_group.test2.id
+					request {
+						method = "GET"
+						url    = "https://welcome.checklyhq.com"
+					}
+				}
+			`,
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttrPair(
+					"checkly_check.test1",
+					"group_id",
+					"checkly_check_group.test2",
+					"id",
+				),
+				resource.TestCheckResourceAttrPair(
+					"checkly_check.test2",
+					"group_id",
+					"checkly_check_group.test2",
+					"id",
+				),
+			),
+		},
+		{
+			Config: `
+				resource "checkly_check_group" "test1" {
+					name        = "test-group-assignment"
+					activated   = true
+					concurrency = 1
+					locations   = ["eu-central-1"]
+				}
+
+				resource "checkly_check_group" "test2" {
+					name        = "test-group-assignment"
+					activated   = true
+					concurrency = 1
+					locations   = ["eu-central-1"]
+				}
+
+				resource "checkly_check" "test1" {
+					name      = "test-group-assignment"
+					type      = "API"
+					activated = true
+					frequency = 60
+					locations = ["eu-central-1"]
+					request {
+						method = "GET"
+						url    = "https://welcome.checklyhq.com"
+					}
+				}
+
+				resource "checkly_check" "test2" {
+					name      = "test-group-assignment"
+					type      = "API"
+					activated = true
+					frequency = 60
+					locations = ["eu-central-1"]
+					request {
+						method = "GET"
+						url    = "https://welcome.checklyhq.com"
+					}
+				}
+			`,
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr(
+					"checkly_check.test1",
+					"group_id",
+					"0",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_check.test2",
+					"group_id",
+					"0",
+				),
+			),
+		},
+	})
+}

--- a/checkly/resource_tcp_monitor_test.go
+++ b/checkly/resource_tcp_monitor_test.go
@@ -1004,3 +1004,167 @@ func TestAccTCPMonitorRetryStrategyRemoval(t *testing.T) {
 		},
 	})
 }
+
+func TestAccTCPMonitorGroupAssignment(t *testing.T) {
+	accTestCase(t, []resource.TestStep{
+		{
+			Config: `
+				resource "checkly_check_group" "test1" {
+					name        = "test-group-assignment"
+					activated   = true
+					concurrency = 1
+					locations   = ["eu-central-1"]
+				}
+
+				resource "checkly_check_group" "test2" {
+					name        = "test-group-assignment"
+					activated   = true
+					concurrency = 1
+					locations   = ["eu-central-1"]
+				}
+
+				resource "checkly_tcp_monitor" "test1" {
+					name      = "test-group-assignment"
+					activated = true
+					frequency = 60
+					locations = ["eu-central-1"]
+					group_id  = checkly_check_group.test1.id
+					request {
+						port     = 443
+						hostname = "checkly.com"
+					}
+				}
+
+				resource "checkly_tcp_monitor" "test2" {
+					name      = "test-group-assignment"
+					activated = true
+					frequency = 60
+					locations = ["eu-central-1"]
+					request {
+						port     = 443
+						hostname = "checkly.com"
+					}
+				}
+			`,
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttrPair(
+					"checkly_tcp_monitor.test1",
+					"group_id",
+					"checkly_check_group.test1",
+					"id",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_tcp_monitor.test2",
+					"group_id",
+					"0",
+				),
+			),
+		},
+		{
+			Config: `
+				resource "checkly_check_group" "test1" {
+					name        = "test-group-assignment"
+					activated   = true
+					concurrency = 1
+					locations   = ["eu-central-1"]
+				}
+
+				resource "checkly_check_group" "test2" {
+					name        = "test-group-assignment"
+					activated   = true
+					concurrency = 1
+					locations   = ["eu-central-1"]
+				}
+
+				resource "checkly_tcp_monitor" "test1" {
+					name      = "test-group-assignment"
+					activated = true
+					frequency = 60
+					locations = ["eu-central-1"]
+					group_id  = checkly_check_group.test2.id
+					request {
+						port     = 443
+						hostname = "checkly.com"
+					}
+				}
+				
+				resource "checkly_tcp_monitor" "test2" {
+					name      = "test-group-assignment"
+					activated = true
+					frequency = 60
+					locations = ["eu-central-1"]
+					group_id  = checkly_check_group.test2.id
+					request {
+						port     = 443
+						hostname = "checkly.com"
+					}
+				}
+			`,
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttrPair(
+					"checkly_tcp_monitor.test1",
+					"group_id",
+					"checkly_check_group.test2",
+					"id",
+				),
+				resource.TestCheckResourceAttrPair(
+					"checkly_tcp_monitor.test2",
+					"group_id",
+					"checkly_check_group.test2",
+					"id",
+				),
+			),
+		},
+		{
+			Config: `
+				resource "checkly_check_group" "test1" {
+					name        = "test-group-assignment"
+					activated   = true
+					concurrency = 1
+					locations   = ["eu-central-1"]
+				}
+
+				resource "checkly_check_group" "test2" {
+					name        = "test-group-assignment"
+					activated   = true
+					concurrency = 1
+					locations   = ["eu-central-1"]
+				}
+
+				resource "checkly_tcp_monitor" "test1" {
+					name      = "test-group-assignment"
+					activated = true
+					frequency = 60
+					locations = ["eu-central-1"]
+					request {
+						port     = 443
+						hostname = "checkly.com"
+					}
+				}
+				
+				resource "checkly_tcp_monitor" "test2" {
+					name      = "test-group-assignment"
+					activated = true
+					frequency = 60
+					locations = ["eu-central-1"]
+					request {
+						port     = 443
+						hostname = "checkly.com"
+					}
+				}
+			`,
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr(
+					"checkly_tcp_monitor.test1",
+					"group_id",
+					"0",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_tcp_monitor.test2",
+					"group_id",
+					"0",
+				),
+			),
+		},
+	})
+}

--- a/checkly/resource_url_monitor_test.go
+++ b/checkly/resource_url_monitor_test.go
@@ -1001,3 +1001,161 @@ func TestAccURLMonitorRetryStrategyRemoval(t *testing.T) {
 		},
 	})
 }
+
+func TestAccURLMonitorGroupAssignment(t *testing.T) {
+	accTestCase(t, []resource.TestStep{
+		{
+			Config: `
+				resource "checkly_check_group" "test1" {
+					name        = "test-group-assignment"
+					activated   = true
+					concurrency = 1
+					locations   = ["eu-central-1"]
+				}
+
+				resource "checkly_check_group" "test2" {
+					name        = "test-group-assignment"
+					activated   = true
+					concurrency = 1
+					locations   = ["eu-central-1"]
+				}
+
+				resource "checkly_url_monitor" "test1" {
+					name      = "test-group-assignment"
+					activated = true
+					frequency = 60
+					locations = ["eu-central-1"]
+					group_id  = checkly_check_group.test1.id
+					request {
+						url = "https://checkly.com"
+					}
+				}
+
+				resource "checkly_url_monitor" "test2" {
+					name      = "test-group-assignment"
+					activated = true
+					frequency = 60
+					locations = ["eu-central-1"]
+					request {
+						url = "https://checkly.com"
+					}
+				}
+			`,
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttrPair(
+					"checkly_url_monitor.test1",
+					"group_id",
+					"checkly_check_group.test1",
+					"id",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_url_monitor.test2",
+					"group_id",
+					"0",
+				),
+			),
+		},
+		{
+			Config: `
+				resource "checkly_check_group" "test1" {
+					name        = "test-group-assignment"
+					activated   = true
+					concurrency = 1
+					locations   = ["eu-central-1"]
+				}
+
+				resource "checkly_check_group" "test2" {
+					name        = "test-group-assignment"
+					activated   = true
+					concurrency = 1
+					locations   = ["eu-central-1"]
+				}
+
+				resource "checkly_url_monitor" "test1" {
+					name      = "test-group-assignment"
+					activated = true
+					frequency = 60
+					locations = ["eu-central-1"]
+					group_id  = checkly_check_group.test2.id
+					request {
+						url = "https://checkly.com"
+					}
+				}
+				
+				resource "checkly_url_monitor" "test2" {
+					name      = "test-group-assignment"
+					activated = true
+					frequency = 60
+					locations = ["eu-central-1"]
+					group_id  = checkly_check_group.test2.id
+					request {
+						url = "https://checkly.com"
+					}
+				}
+			`,
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttrPair(
+					"checkly_url_monitor.test1",
+					"group_id",
+					"checkly_check_group.test2",
+					"id",
+				),
+				resource.TestCheckResourceAttrPair(
+					"checkly_url_monitor.test2",
+					"group_id",
+					"checkly_check_group.test2",
+					"id",
+				),
+			),
+		},
+		{
+			Config: `
+				resource "checkly_check_group" "test1" {
+					name        = "test-group-assignment"
+					activated   = true
+					concurrency = 1
+					locations   = ["eu-central-1"]
+				}
+
+				resource "checkly_check_group" "test2" {
+					name        = "test-group-assignment"
+					activated   = true
+					concurrency = 1
+					locations   = ["eu-central-1"]
+				}
+
+				resource "checkly_url_monitor" "test1" {
+					name      = "test-group-assignment"
+					activated = true
+					frequency = 60
+					locations = ["eu-central-1"]
+					request {
+						url = "https://checkly.com"
+					}
+				}
+				
+				resource "checkly_url_monitor" "test2" {
+					name      = "test-group-assignment"
+					activated = true
+					frequency = 60
+					locations = ["eu-central-1"]
+					request {
+						url = "https://checkly.com"
+					}
+				}
+			`,
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr(
+					"checkly_url_monitor.test1",
+					"group_id",
+					"0",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_url_monitor.test2",
+					"group_id",
+					"0",
+				),
+			),
+		},
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24.0
 
 require (
 	github.com/aws/aws-sdk-go v1.44.122 // indirect
-	github.com/checkly/checkly-go-sdk v1.15.0
+	github.com/checkly/checkly-go-sdk v1.16.0
 	github.com/google/go-cmp v0.7.0
 	github.com/gruntwork-io/terratest v0.41.16
 	github.com/hashicorp/terraform-plugin-docs v0.19.4

--- a/go.sum
+++ b/go.sum
@@ -251,8 +251,8 @@ github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghf
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/checkly/checkly-go-sdk v1.15.0 h1:H8157N+/MrF8KebPgFAK/9fJxFSeseegUJAwDyHoMKo=
-github.com/checkly/checkly-go-sdk v1.15.0/go.mod h1:Pd6tBOggAe41NnCU5KwqA8JvD6J20/IctszT2E0AvHo=
+github.com/checkly/checkly-go-sdk v1.16.0 h1:m8ixcmHlNxnls/sFlcAa48j3xrvEcBaDcHnYOL9gbZM=
+github.com/checkly/checkly-go-sdk v1.16.0/go.mod h1:Pd6tBOggAe41NnCU5KwqA8JvD6J20/IctszT2E0AvHo=
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=


### PR DESCRIPTION
This PR fixes an issue with group assignment. Previously, you'd be unable to unassigned a check/monitor from a group once it was set. You'd be able to assign another group, but never remove the group entirely. Now removal is possible.

Updates checkly-go-sdk to v1.16.0 because https://github.com/checkly/checkly-go-sdk/pull/144 is needed.

## Affected Components
* [x] Resources
* [x] Test
* [ ] Docs
* [ ] Tooling
* [ ] Other

## Pre-Requisites
* [x] Terraform code is formatted with `terraform fmt`
* [x] Go code is formatted with `go fmt`
* [ ] `plan` & `apply` command of `demo/main.tf` file do not produce diffs

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #[issue-number]

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
