### PR TITLE
feat: add check descriptions [TREE-736]

### DIFF
--- a/checkly/helpers.go
+++ b/checkly/helpers.go
@@ -121,10 +121,3 @@ func optionalStringPointerFromResourceData(d *schema.ResourceData, key string) *
 	return &str
 }
 
-func setOptionalStringResourceData(d *schema.ResourceData, key string, value *string) error {
-	if value == nil {
-		return d.Set(key, nil)
-	}
-
-	return d.Set(key, *value)
-}

--- a/checkly/helpers.go
+++ b/checkly/helpers.go
@@ -109,7 +109,7 @@ func encodeNumericID(id int64) string {
 }
 
 func optionalStringPointerFromResourceData(d *schema.ResourceData, key string) *string {
-	value, ok := d.GetOkExists(key)
+	value, ok := d.GetOk(key)
 	if !ok {
 		return nil
 	}

--- a/checkly/helpers.go
+++ b/checkly/helpers.go
@@ -9,6 +9,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func apiCallTimeout() time.Duration {
@@ -104,4 +106,25 @@ func decodeNumericID(id string) (int64, error) {
 
 func encodeNumericID(id int64) string {
 	return strconv.FormatInt(id, 10)
+}
+
+func optionalStringPointerFromResourceData(d *schema.ResourceData, key string) *string {
+	value, ok := d.GetOkExists(key)
+	if !ok {
+		return nil
+	}
+
+	str := value.(string)
+	if str == "" {
+		return nil
+	}
+	return &str
+}
+
+func setOptionalStringResourceData(d *schema.ResourceData, key string, value *string) error {
+	if value == nil {
+		return d.Set(key, nil)
+	}
+
+	return d.Set(key, *value)
 }

--- a/checkly/helpers.go
+++ b/checkly/helpers.go
@@ -113,11 +113,7 @@ func optionalStringPointerFromResourceData(d *schema.ResourceData, key string) *
 	if !ok {
 		return nil
 	}
-
 	str := value.(string)
-	if str == "" {
-		return nil
-	}
 	return &str
 }
 

--- a/checkly/resource_check.go
+++ b/checkly/resource_check.go
@@ -418,9 +418,7 @@ func resourceCheckDelete(d *schema.ResourceData, client interface{}) error {
 
 func resourceDataFromCheck(c *checkly.Check, d *schema.ResourceData) error {
 	d.Set("name", c.Name)
-	if err := setOptionalStringResourceData(d, "description", c.Description); err != nil {
-		return fmt.Errorf("error setting description for resource %s: %w", d.Id(), err)
-	}
+	d.Set("description", c.Description)
 	d.Set("type", c.Type)
 	d.Set("activated", c.Activated)
 	d.Set("muted", c.Muted)

--- a/checkly/resource_check.go
+++ b/checkly/resource_check.go
@@ -418,10 +418,8 @@ func resourceCheckDelete(d *schema.ResourceData, client interface{}) error {
 
 func resourceDataFromCheck(c *checkly.Check, d *schema.ResourceData) error {
 	d.Set("name", c.Name)
-	if c.Description == "" {
-		d.Set("description", nil)
-	} else {
-		d.Set("description", c.Description)
+	if err := setOptionalStringResourceData(d, "description", c.Description); err != nil {
+		return fmt.Errorf("error setting description for resource %s: %w", d.Id(), err)
 	}
 	d.Set("type", c.Type)
 	d.Set("activated", c.Activated)
@@ -535,7 +533,7 @@ func checkFromResourceData(d *schema.ResourceData) (checkly.Check, error) {
 	check := checkly.Check{
 		ID:                        d.Id(),
 		Name:                      d.Get("name").(string),
-		Description:               d.Get("description").(string),
+		Description:               optionalStringPointerFromResourceData(d, "description"),
 		Type:                      d.Get("type").(string),
 		Frequency:                 d.Get(frequencyAttributeName).(int),
 		Activated:                 d.Get("activated").(bool),

--- a/checkly/resource_check.go
+++ b/checkly/resource_check.go
@@ -418,7 +418,11 @@ func resourceCheckDelete(d *schema.ResourceData, client interface{}) error {
 
 func resourceDataFromCheck(c *checkly.Check, d *schema.ResourceData) error {
 	d.Set("name", c.Name)
-	d.Set("description", c.Description)
+	if c.Description == "" {
+		d.Set("description", nil)
+	} else {
+		d.Set("description", c.Description)
+	}
 	d.Set("type", c.Type)
 	d.Set("activated", c.Activated)
 	d.Set("muted", c.Muted)

--- a/checkly/resource_check.go
+++ b/checkly/resource_check.go
@@ -33,6 +33,11 @@ func resourceCheck() *schema.Resource {
 				Required:    true,
 				Description: "The name of the check.",
 			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "A description of the check.",
+			},
 			"type": {
 				Type:        schema.TypeString,
 				Required:    true,
@@ -413,6 +418,7 @@ func resourceCheckDelete(d *schema.ResourceData, client interface{}) error {
 
 func resourceDataFromCheck(c *checkly.Check, d *schema.ResourceData) error {
 	d.Set("name", c.Name)
+	d.Set("description", c.Description)
 	d.Set("type", c.Type)
 	d.Set("activated", c.Activated)
 	d.Set("muted", c.Muted)
@@ -525,6 +531,7 @@ func checkFromResourceData(d *schema.ResourceData) (checkly.Check, error) {
 	check := checkly.Check{
 		ID:                        d.Id(),
 		Name:                      d.Get("name").(string),
+		Description:               d.Get("description").(string),
 		Type:                      d.Get("type").(string),
 		Frequency:                 d.Get(frequencyAttributeName).(int),
 		Activated:                 d.Get("activated").(bool),

--- a/checkly/resource_check_test.go
+++ b/checkly/resource_check_test.go
@@ -1352,7 +1352,11 @@ func TestAccCheckDescriptionRemoval(t *testing.T) {
 		},
 		{
 			Config: apiCheck_basic_withoutDescription,
-			Check:  testCheckOptionalAttrRemoved("checkly_check.test", "description"),
+			Check: resource.TestCheckResourceAttr(
+				"checkly_check.test",
+				"description",
+				"",
+			),
 		},
 	})
 }

--- a/checkly/resource_check_test.go
+++ b/checkly/resource_check_test.go
@@ -100,6 +100,11 @@ func TestAccBrowserCheckBasic(t *testing.T) {
 				),
 				resource.TestCheckResourceAttr(
 					"checkly_check.test",
+					"description",
+					"Browser check description",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_check.test",
 					"type",
 					"BROWSER",
 				),
@@ -162,6 +167,11 @@ func TestAccApiCheckBasic(t *testing.T) {
 					"checkly_check.test",
 					"name",
 					"API Check 1",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_check.test",
+					"description",
+					"API check description",
 				),
 				resource.TestCheckResourceAttr(
 					"checkly_check.test",
@@ -588,6 +598,7 @@ EOT
 
 var wantCheck = checkly.Check{
 	Name:                 "My test check",
+	Description:          "My test check description",
 	Type:                 checkly.TypeAPI,
 	Frequency:            1,
 	Activated:            true,
@@ -1327,9 +1338,30 @@ func TestAccCheckRetryStrategyRemoval(t *testing.T) {
 	})
 }
 
+func TestAccCheckDescriptionRemoval(t *testing.T) {
+	accTestCase(t, []resource.TestStep{
+		{
+			Config: apiCheck_basic,
+			Check: resource.TestCheckResourceAttr(
+				"checkly_check.test",
+				"description",
+				"API check description",
+			),
+		},
+		{
+			Config: apiCheck_basic_withoutDescription,
+			Check: resource.TestCheckNoResourceAttr(
+				"checkly_check.test",
+				"description",
+			),
+		},
+	})
+}
+
 const browserCheck_basic = `
 	resource "checkly_check" "test" {
 		name                      = "Browser Check"
+		description               = "Browser check description"
 		type                      = "BROWSER"
 		activated                 = true
 		should_fail               = false
@@ -1358,6 +1390,31 @@ const multiStepCheck_basic = `
 `
 
 const apiCheck_basic = `
+	resource "checkly_check" "test" {
+	  name                      = "API Check 1"
+	  description               = "API check description"
+	  type                      = "API"
+	  frequency                 = 60
+	  activated                 = true
+	  muted                     = true
+	  double_check              = true
+	  max_response_time         = 18000
+	  locations                 = [ "us-east-1", "eu-central-1" ]
+	  use_global_alert_settings = true
+	  request {
+		method     = "GET"
+		url        = "https://api.checklyhq.com/public-stats"
+		assertion {
+		  comparison = "EQUALS"
+		  property   = ""
+		  source     = "STATUS_CODE"
+		  target     = "200"
+		}
+	  }
+	}
+`
+
+const apiCheck_basic_withoutDescription = `
 	resource "checkly_check" "test" {
 	  name                      = "API Check 1"
 	  type                      = "API"

--- a/checkly/resource_check_test.go
+++ b/checkly/resource_check_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/checkly/checkly-go-sdk"
 )
@@ -1350,9 +1351,18 @@ func TestAccCheckDescriptionRemoval(t *testing.T) {
 		},
 		{
 			Config: apiCheck_basic_withoutDescription,
-			Check: resource.TestCheckNoResourceAttr(
-				"checkly_check.test",
-				"description",
+			Check: resource.ComposeTestCheckFunc(
+				func(s *terraform.State) error {
+					value, ok := s.Modules[0].Resources["checkly_check.test"].Primary.Attributes["description"]
+					if !ok || value == "" {
+						return nil
+					}
+
+					return resource.TestCheckNoResourceAttr(
+						"checkly_check.test",
+						"description",
+					)(s)
+				},
 			),
 		},
 	})

--- a/checkly/resource_check_test.go
+++ b/checkly/resource_check_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/checkly/checkly-go-sdk"
 )
@@ -1352,9 +1353,18 @@ func TestAccCheckDescriptionRemoval(t *testing.T) {
 		},
 		{
 			Config: apiCheck_basic_withoutDescription,
-			Check: resource.TestCheckNoResourceAttr(
-				"checkly_check.test",
-				"description",
+			Check: resource.ComposeTestCheckFunc(
+				func(s *terraform.State) error {
+					value, ok := s.Modules[0].Resources["checkly_check.test"].Primary.Attributes["description"]
+					if !ok || value == "" {
+						return nil
+					}
+
+					return resource.TestCheckNoResourceAttr(
+						"checkly_check.test",
+						"description",
+					)(s)
+				},
 			),
 		},
 	})

--- a/checkly/resource_check_test.go
+++ b/checkly/resource_check_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/checkly/checkly-go-sdk"
 )
@@ -1353,19 +1352,7 @@ func TestAccCheckDescriptionRemoval(t *testing.T) {
 		},
 		{
 			Config: apiCheck_basic_withoutDescription,
-			Check: resource.ComposeTestCheckFunc(
-				func(s *terraform.State) error {
-					value, ok := s.Modules[0].Resources["checkly_check.test"].Primary.Attributes["description"]
-					if !ok || value == "" {
-						return nil
-					}
-
-					return resource.TestCheckNoResourceAttr(
-						"checkly_check.test",
-						"description",
-					)(s)
-				},
-			),
+			Check:  testCheckOptionalAttrRemoved("checkly_check.test", "description"),
 		},
 	})
 }

--- a/checkly/resource_check_test.go
+++ b/checkly/resource_check_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/checkly/checkly-go-sdk"
 )
@@ -597,9 +596,11 @@ EOT
 	})
 }
 
+var wantCheckDescription = "My test check description"
+
 var wantCheck = checkly.Check{
 	Name:                 "My test check",
-	Description:          "My test check description",
+	Description:          &wantCheckDescription,
 	Type:                 checkly.TypeAPI,
 	Frequency:            1,
 	Activated:            true,
@@ -1351,18 +1352,9 @@ func TestAccCheckDescriptionRemoval(t *testing.T) {
 		},
 		{
 			Config: apiCheck_basic_withoutDescription,
-			Check: resource.ComposeTestCheckFunc(
-				func(s *terraform.State) error {
-					value, ok := s.Modules[0].Resources["checkly_check.test"].Primary.Attributes["description"]
-					if !ok || value == "" {
-						return nil
-					}
-
-					return resource.TestCheckNoResourceAttr(
-						"checkly_check.test",
-						"description",
-					)(s)
-				},
+			Check: resource.TestCheckNoResourceAttr(
+				"checkly_check.test",
+				"description",
 			),
 		},
 	})

--- a/checkly/resource_dns_monitor.go
+++ b/checkly/resource_dns_monitor.go
@@ -274,10 +274,8 @@ func resourceDNSMonitorDelete(d *schema.ResourceData, client interface{}) error 
 
 func resourceDataFromDNSMonitor(c *checkly.DNSMonitor, d *schema.ResourceData) error {
 	d.Set("name", c.Name)
-	if c.Description == "" {
-		d.Set("description", nil)
-	} else {
-		d.Set("description", c.Description)
+	if err := setOptionalStringResourceData(d, "description", c.Description); err != nil {
+		return fmt.Errorf("error setting description for resource %s: %w", d.Id(), err)
 	}
 	d.Set("activated", c.Activated)
 	d.Set("muted", c.Muted)
@@ -318,7 +316,7 @@ func dnsMonitorFromResourceData(d *schema.ResourceData) (checkly.DNSMonitor, err
 	check := checkly.DNSMonitor{
 		ID:                        d.Id(),
 		Name:                      d.Get("name").(string),
-		Description:               d.Get("description").(string),
+		Description:               optionalStringPointerFromResourceData(d, "description"),
 		Frequency:                 d.Get(frequencyAttributeName).(int),
 		Activated:                 d.Get("activated").(bool),
 		Muted:                     d.Get("muted").(bool),

--- a/checkly/resource_dns_monitor.go
+++ b/checkly/resource_dns_monitor.go
@@ -274,7 +274,11 @@ func resourceDNSMonitorDelete(d *schema.ResourceData, client interface{}) error 
 
 func resourceDataFromDNSMonitor(c *checkly.DNSMonitor, d *schema.ResourceData) error {
 	d.Set("name", c.Name)
-	d.Set("description", c.Description)
+	if c.Description == "" {
+		d.Set("description", nil)
+	} else {
+		d.Set("description", c.Description)
+	}
 	d.Set("activated", c.Activated)
 	d.Set("muted", c.Muted)
 	d.Set("run_parallel", c.RunParallel)

--- a/checkly/resource_dns_monitor.go
+++ b/checkly/resource_dns_monitor.go
@@ -274,9 +274,7 @@ func resourceDNSMonitorDelete(d *schema.ResourceData, client interface{}) error 
 
 func resourceDataFromDNSMonitor(c *checkly.DNSMonitor, d *schema.ResourceData) error {
 	d.Set("name", c.Name)
-	if err := setOptionalStringResourceData(d, "description", c.Description); err != nil {
-		return fmt.Errorf("error setting description for resource %s: %w", d.Id(), err)
-	}
+	d.Set("description", c.Description)
 	d.Set("activated", c.Activated)
 	d.Set("muted", c.Muted)
 	d.Set("run_parallel", c.RunParallel)

--- a/checkly/resource_dns_monitor.go
+++ b/checkly/resource_dns_monitor.go
@@ -27,6 +27,11 @@ func resourceDNSMonitor() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 			},
+			"description": {
+				Description: "A description of the monitor.",
+				Type:        schema.TypeString,
+				Optional:    true,
+			},
 			frequencyAttributeName: makeFrequencyAttributeSchema(FrequencyAttributeSchemaOptions{
 				Monitor:            true,
 				AllowHighFrequency: true,
@@ -269,6 +274,7 @@ func resourceDNSMonitorDelete(d *schema.ResourceData, client interface{}) error 
 
 func resourceDataFromDNSMonitor(c *checkly.DNSMonitor, d *schema.ResourceData) error {
 	d.Set("name", c.Name)
+	d.Set("description", c.Description)
 	d.Set("activated", c.Activated)
 	d.Set("muted", c.Muted)
 	d.Set("run_parallel", c.RunParallel)
@@ -308,6 +314,7 @@ func dnsMonitorFromResourceData(d *schema.ResourceData) (checkly.DNSMonitor, err
 	check := checkly.DNSMonitor{
 		ID:                        d.Id(),
 		Name:                      d.Get("name").(string),
+		Description:               d.Get("description").(string),
 		Frequency:                 d.Get(frequencyAttributeName).(int),
 		Activated:                 d.Get("activated").(bool),
 		Muted:                     d.Get("muted").(bool),

--- a/checkly/resource_dns_monitor_test.go
+++ b/checkly/resource_dns_monitor_test.go
@@ -174,7 +174,11 @@ func TestAccDNSMonitorDescriptionRemoval(t *testing.T) {
 					}
 				}
 			`,
-			Check: testCheckOptionalAttrRemoved("checkly_dns_monitor.test", "description"),
+			Check: resource.TestCheckResourceAttr(
+				"checkly_dns_monitor.test",
+				"description",
+				"",
+			),
 		},
 	})
 }

--- a/checkly/resource_dns_monitor_test.go
+++ b/checkly/resource_dns_monitor_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/checkly/checkly-go-sdk"
 )
@@ -175,18 +174,9 @@ func TestAccDNSMonitorDescriptionRemoval(t *testing.T) {
 					}
 				}
 			`,
-			Check: resource.ComposeTestCheckFunc(
-				func(s *terraform.State) error {
-					value, ok := s.Modules[0].Resources["checkly_dns_monitor.test"].Primary.Attributes["description"]
-					if !ok || value == "" {
-						return nil
-					}
-
-					return resource.TestCheckNoResourceAttr(
-						"checkly_dns_monitor.test",
-						"description",
-					)(s)
-				},
+			Check: resource.TestCheckNoResourceAttr(
+				"checkly_dns_monitor.test",
+				"description",
 			),
 		},
 	})

--- a/checkly/resource_dns_monitor_test.go
+++ b/checkly/resource_dns_monitor_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/checkly/checkly-go-sdk"
 )
@@ -174,9 +175,18 @@ func TestAccDNSMonitorDescriptionRemoval(t *testing.T) {
 					}
 				}
 			`,
-			Check: resource.TestCheckNoResourceAttr(
-				"checkly_dns_monitor.test",
-				"description",
+			Check: resource.ComposeTestCheckFunc(
+				func(s *terraform.State) error {
+					value, ok := s.Modules[0].Resources["checkly_dns_monitor.test"].Primary.Attributes["description"]
+					if !ok || value == "" {
+						return nil
+					}
+
+					return resource.TestCheckNoResourceAttr(
+						"checkly_dns_monitor.test",
+						"description",
+					)(s)
+				},
 			),
 		},
 	})

--- a/checkly/resource_dns_monitor_test.go
+++ b/checkly/resource_dns_monitor_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/checkly/checkly-go-sdk"
 )
@@ -175,19 +174,7 @@ func TestAccDNSMonitorDescriptionRemoval(t *testing.T) {
 					}
 				}
 			`,
-			Check: resource.ComposeTestCheckFunc(
-				func(s *terraform.State) error {
-					value, ok := s.Modules[0].Resources["checkly_dns_monitor.test"].Primary.Attributes["description"]
-					if !ok || value == "" {
-						return nil
-					}
-
-					return resource.TestCheckNoResourceAttr(
-						"checkly_dns_monitor.test",
-						"description",
-					)(s)
-				},
-			),
+			Check: testCheckOptionalAttrRemoved("checkly_dns_monitor.test", "description"),
 		},
 	})
 }

--- a/checkly/resource_dns_monitor_test.go
+++ b/checkly/resource_dns_monitor_test.go
@@ -38,6 +38,7 @@ func TestAccDNSMonitorBasic(t *testing.T) {
 			Config: `
 				resource "checkly_dns_monitor" "test" {
 					name                      = "DNS Monitor 1"
+					description               = "DNS monitor description"
 					frequency                 = 60
 					activated                 = true
 					muted                     = true
@@ -62,6 +63,11 @@ func TestAccDNSMonitorBasic(t *testing.T) {
 					"checkly_dns_monitor.test",
 					"name",
 					"DNS Monitor 1",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_dns_monitor.test",
+					"description",
+					"DNS monitor description",
 				),
 				resource.TestCheckResourceAttr(
 					"checkly_dns_monitor.test",
@@ -108,6 +114,69 @@ func TestAccDNSMonitorBasic(t *testing.T) {
 					"request.*.assertion.*.target",
 					"NOERROR",
 				),
+			),
+		},
+	})
+}
+
+func TestAccDNSMonitorDescriptionRemoval(t *testing.T) {
+	accTestCase(t, []resource.TestStep{
+		{
+			Config: `
+				resource "checkly_dns_monitor" "test" {
+					name                      = "DNS Monitor 1"
+					description               = "DNS monitor description"
+					frequency                 = 60
+					activated                 = true
+					muted                     = true
+					max_response_time         = 3000
+					locations                 = ["us-east-1", "eu-central-1"]
+					use_global_alert_settings = true
+
+					request {
+						record_type = "A"
+						query       = "welcome.checklyhq.com"
+
+						assertion {
+							source     = "RESPONSE_CODE"
+							comparison = "EQUALS"
+							target     = "NOERROR"
+						}
+					}
+				}
+			`,
+			Check: resource.TestCheckResourceAttr(
+				"checkly_dns_monitor.test",
+				"description",
+				"DNS monitor description",
+			),
+		},
+		{
+			Config: `
+				resource "checkly_dns_monitor" "test" {
+					name                      = "DNS Monitor 1"
+					frequency                 = 60
+					activated                 = true
+					muted                     = true
+					max_response_time         = 3000
+					locations                 = ["us-east-1", "eu-central-1"]
+					use_global_alert_settings = true
+
+					request {
+						record_type = "A"
+						query       = "welcome.checklyhq.com"
+
+						assertion {
+							source     = "RESPONSE_CODE"
+							comparison = "EQUALS"
+							target     = "NOERROR"
+						}
+					}
+				}
+			`,
+			Check: resource.TestCheckNoResourceAttr(
+				"checkly_dns_monitor.test",
+				"description",
 			),
 		},
 	})

--- a/checkly/resource_heartbeat_monitor.go
+++ b/checkly/resource_heartbeat_monitor.go
@@ -30,6 +30,11 @@ func resourceHeartbeatMonitor() *schema.Resource {
 				Required:    true,
 				Description: "The name of the check.",
 			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "A description of the check.",
+			},
 			"activated": {
 				Type:        schema.TypeBool,
 				Required:    true,
@@ -192,6 +197,7 @@ func heartbeatMonitorFromResourceData(d *schema.ResourceData) (checkly.Heartbeat
 	monitor := checkly.HeartbeatMonitor{
 		ID:                        d.Id(),
 		Name:                      d.Get("name").(string),
+		Description:               d.Get("description").(string),
 		Activated:                 d.Get("activated").(bool),
 		Muted:                     d.Get("muted").(bool),
 		Tags:                      stringsFromSet(d.Get("tags").(*schema.Set)),
@@ -257,6 +263,7 @@ func heartbeatMonitorFromResourceData(d *schema.ResourceData) (checkly.Heartbeat
 
 func resourceDataFromHeartbeatMonitor(c *checkly.HeartbeatMonitor, d *schema.ResourceData) error {
 	d.Set("name", c.Name)
+	d.Set("description", c.Description)
 	d.Set("activated", c.Activated)
 	d.Set("muted", c.Muted)
 

--- a/checkly/resource_heartbeat_monitor.go
+++ b/checkly/resource_heartbeat_monitor.go
@@ -197,7 +197,7 @@ func heartbeatMonitorFromResourceData(d *schema.ResourceData) (checkly.Heartbeat
 	monitor := checkly.HeartbeatMonitor{
 		ID:                        d.Id(),
 		Name:                      d.Get("name").(string),
-		Description:               d.Get("description").(string),
+		Description:               optionalStringPointerFromResourceData(d, "description"),
 		Activated:                 d.Get("activated").(bool),
 		Muted:                     d.Get("muted").(bool),
 		Tags:                      stringsFromSet(d.Get("tags").(*schema.Set)),
@@ -263,10 +263,8 @@ func heartbeatMonitorFromResourceData(d *schema.ResourceData) (checkly.Heartbeat
 
 func resourceDataFromHeartbeatMonitor(c *checkly.HeartbeatMonitor, d *schema.ResourceData) error {
 	d.Set("name", c.Name)
-	if c.Description == "" {
-		d.Set("description", nil)
-	} else {
-		d.Set("description", c.Description)
+	if err := setOptionalStringResourceData(d, "description", c.Description); err != nil {
+		return fmt.Errorf("error setting description for resource %s: %w", d.Id(), err)
 	}
 	d.Set("activated", c.Activated)
 	d.Set("muted", c.Muted)

--- a/checkly/resource_heartbeat_monitor.go
+++ b/checkly/resource_heartbeat_monitor.go
@@ -263,7 +263,11 @@ func heartbeatMonitorFromResourceData(d *schema.ResourceData) (checkly.Heartbeat
 
 func resourceDataFromHeartbeatMonitor(c *checkly.HeartbeatMonitor, d *schema.ResourceData) error {
 	d.Set("name", c.Name)
-	d.Set("description", c.Description)
+	if c.Description == "" {
+		d.Set("description", nil)
+	} else {
+		d.Set("description", c.Description)
+	}
 	d.Set("activated", c.Activated)
 	d.Set("muted", c.Muted)
 

--- a/checkly/resource_heartbeat_monitor.go
+++ b/checkly/resource_heartbeat_monitor.go
@@ -33,7 +33,7 @@ func resourceHeartbeatMonitor() *schema.Resource {
 			"description": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: "A description of the check.",
+				Description: "A description of the monitor.",
 			},
 			"activated": {
 				Type:        schema.TypeBool,

--- a/checkly/resource_heartbeat_monitor.go
+++ b/checkly/resource_heartbeat_monitor.go
@@ -263,9 +263,7 @@ func heartbeatMonitorFromResourceData(d *schema.ResourceData) (checkly.Heartbeat
 
 func resourceDataFromHeartbeatMonitor(c *checkly.HeartbeatMonitor, d *schema.ResourceData) error {
 	d.Set("name", c.Name)
-	if err := setOptionalStringResourceData(d, "description", c.Description); err != nil {
-		return fmt.Errorf("error setting description for resource %s: %w", d.Id(), err)
-	}
+	d.Set("description", c.Description)
 	d.Set("activated", c.Activated)
 	d.Set("muted", c.Muted)
 

--- a/checkly/resource_heartbeat_monitor_test.go
+++ b/checkly/resource_heartbeat_monitor_test.go
@@ -228,7 +228,11 @@ func TestAccHeartbeatMonitorDescriptionRemoval(t *testing.T) {
 					grace_unit = "seconds"
 				}
 			}`,
-			Check: testCheckOptionalAttrRemoved("checkly_heartbeat_monitor.test", "description"),
+			Check: resource.TestCheckResourceAttr(
+				"checkly_heartbeat_monitor.test",
+				"description",
+				"",
+			),
 		},
 	})
 }

--- a/checkly/resource_heartbeat_monitor_test.go
+++ b/checkly/resource_heartbeat_monitor_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccHeartbeatMonitorRequiredFields(t *testing.T) {
@@ -229,19 +228,7 @@ func TestAccHeartbeatMonitorDescriptionRemoval(t *testing.T) {
 					grace_unit = "seconds"
 				}
 			}`,
-			Check: resource.ComposeTestCheckFunc(
-				func(s *terraform.State) error {
-					value, ok := s.Modules[0].Resources["checkly_heartbeat_monitor.test"].Primary.Attributes["description"]
-					if !ok || value == "" {
-						return nil
-					}
-
-					return resource.TestCheckNoResourceAttr(
-						"checkly_heartbeat_monitor.test",
-						"description",
-					)(s)
-				},
-			),
+			Check: testCheckOptionalAttrRemoved("checkly_heartbeat_monitor.test", "description"),
 		},
 	})
 }

--- a/checkly/resource_heartbeat_monitor_test.go
+++ b/checkly/resource_heartbeat_monitor_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccHeartbeatMonitorRequiredFields(t *testing.T) {
@@ -228,9 +229,18 @@ func TestAccHeartbeatMonitorDescriptionRemoval(t *testing.T) {
 					grace_unit = "seconds"
 				}
 			}`,
-			Check: resource.TestCheckNoResourceAttr(
-				"checkly_heartbeat_monitor.test",
-				"description",
+			Check: resource.ComposeTestCheckFunc(
+				func(s *terraform.State) error {
+					value, ok := s.Modules[0].Resources["checkly_heartbeat_monitor.test"].Primary.Attributes["description"]
+					if !ok || value == "" {
+						return nil
+					}
+
+					return resource.TestCheckNoResourceAttr(
+						"checkly_heartbeat_monitor.test",
+						"description",
+					)(s)
+				},
 			),
 		},
 	})

--- a/checkly/resource_heartbeat_monitor_test.go
+++ b/checkly/resource_heartbeat_monitor_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccHeartbeatMonitorRequiredFields(t *testing.T) {
@@ -229,18 +228,9 @@ func TestAccHeartbeatMonitorDescriptionRemoval(t *testing.T) {
 					grace_unit = "seconds"
 				}
 			}`,
-			Check: resource.ComposeTestCheckFunc(
-				func(s *terraform.State) error {
-					value, ok := s.Modules[0].Resources["checkly_heartbeat_monitor.test"].Primary.Attributes["description"]
-					if !ok || value == "" {
-						return nil
-					}
-
-					return resource.TestCheckNoResourceAttr(
-						"checkly_heartbeat_monitor.test",
-						"description",
-					)(s)
-				},
+			Check: resource.TestCheckNoResourceAttr(
+				"checkly_heartbeat_monitor.test",
+				"description",
 			),
 		},
 	})

--- a/checkly/resource_heartbeat_monitor_test.go
+++ b/checkly/resource_heartbeat_monitor_test.go
@@ -160,6 +160,7 @@ func TestAccHeartbeatMonitorCreate(t *testing.T) {
 	config := `resource "checkly_heartbeat_monitor" "test" {
 		activated = true
 		name = "heartbeat monitor"
+		description = "Heartbeat monitor description"
 		heartbeat {
 			period = 5
 			period_unit = "days"
@@ -176,6 +177,11 @@ func TestAccHeartbeatMonitorCreate(t *testing.T) {
 					"name",
 					"heartbeat monitor",
 				),
+				resource.TestCheckResourceAttr(
+					"checkly_heartbeat_monitor.test",
+					"description",
+					"Heartbeat monitor description",
+				),
 				testCheckResourceAttrExpr(
 					"checkly_heartbeat_monitor.test",
 					"heartbeat.*.period",
@@ -186,6 +192,45 @@ func TestAccHeartbeatMonitorCreate(t *testing.T) {
 					"heartbeat.*.period_unit",
 					"days",
 				),
+			),
+		},
+	})
+}
+
+func TestAccHeartbeatMonitorDescriptionRemoval(t *testing.T) {
+	accTestCase(t, []resource.TestStep{
+		{
+			Config: `resource "checkly_heartbeat_monitor" "test" {
+				activated = true
+				name = "heartbeat monitor"
+				description = "Heartbeat monitor description"
+				heartbeat {
+					period = 5
+					period_unit = "days"
+					grace = 0
+					grace_unit = "seconds"
+				}
+			}`,
+			Check: resource.TestCheckResourceAttr(
+				"checkly_heartbeat_monitor.test",
+				"description",
+				"Heartbeat monitor description",
+			),
+		},
+		{
+			Config: `resource "checkly_heartbeat_monitor" "test" {
+				activated = true
+				name = "heartbeat monitor"
+				heartbeat {
+					period = 5
+					period_unit = "days"
+					grace = 0
+					grace_unit = "seconds"
+				}
+			}`,
+			Check: resource.TestCheckNoResourceAttr(
+				"checkly_heartbeat_monitor.test",
+				"description",
 			),
 		},
 	})

--- a/checkly/resource_icmp_monitor.go
+++ b/checkly/resource_icmp_monitor.go
@@ -248,7 +248,11 @@ func resourceICMPMonitorDelete(d *schema.ResourceData, client interface{}) error
 
 func resourceDataFromICMPMonitor(c *checkly.ICMPMonitor, d *schema.ResourceData) error {
 	d.Set("name", c.Name)
-	d.Set("description", c.Description)
+	if c.Description == "" {
+		d.Set("description", nil)
+	} else {
+		d.Set("description", c.Description)
+	}
 	d.Set("activated", c.Activated)
 	d.Set("muted", c.Muted)
 	d.Set("run_parallel", c.RunParallel)

--- a/checkly/resource_icmp_monitor.go
+++ b/checkly/resource_icmp_monitor.go
@@ -248,9 +248,7 @@ func resourceICMPMonitorDelete(d *schema.ResourceData, client interface{}) error
 
 func resourceDataFromICMPMonitor(c *checkly.ICMPMonitor, d *schema.ResourceData) error {
 	d.Set("name", c.Name)
-	if err := setOptionalStringResourceData(d, "description", c.Description); err != nil {
-		return fmt.Errorf("error setting description for resource %s: %w", d.Id(), err)
-	}
+	d.Set("description", c.Description)
 	d.Set("activated", c.Activated)
 	d.Set("muted", c.Muted)
 	d.Set("run_parallel", c.RunParallel)

--- a/checkly/resource_icmp_monitor.go
+++ b/checkly/resource_icmp_monitor.go
@@ -27,6 +27,11 @@ func resourceICMPMonitor() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 			},
+			"description": {
+				Description: "A description of the monitor.",
+				Type:        schema.TypeString,
+				Optional:    true,
+			},
 			frequencyAttributeName: makeFrequencyAttributeSchema(FrequencyAttributeSchemaOptions{
 				Monitor:            true,
 				AllowHighFrequency: true,
@@ -243,6 +248,7 @@ func resourceICMPMonitorDelete(d *schema.ResourceData, client interface{}) error
 
 func resourceDataFromICMPMonitor(c *checkly.ICMPMonitor, d *schema.ResourceData) error {
 	d.Set("name", c.Name)
+	d.Set("description", c.Description)
 	d.Set("activated", c.Activated)
 	d.Set("muted", c.Muted)
 	d.Set("run_parallel", c.RunParallel)
@@ -282,6 +288,7 @@ func icmpMonitorFromResourceData(d *schema.ResourceData) (checkly.ICMPMonitor, e
 	monitor := checkly.ICMPMonitor{
 		ID:                          d.Id(),
 		Name:                        d.Get("name").(string),
+		Description:                 d.Get("description").(string),
 		Frequency:                   d.Get(frequencyAttributeName).(int),
 		Activated:                   d.Get("activated").(bool),
 		Muted:                       d.Get("muted").(bool),

--- a/checkly/resource_icmp_monitor.go
+++ b/checkly/resource_icmp_monitor.go
@@ -248,10 +248,8 @@ func resourceICMPMonitorDelete(d *schema.ResourceData, client interface{}) error
 
 func resourceDataFromICMPMonitor(c *checkly.ICMPMonitor, d *schema.ResourceData) error {
 	d.Set("name", c.Name)
-	if c.Description == "" {
-		d.Set("description", nil)
-	} else {
-		d.Set("description", c.Description)
+	if err := setOptionalStringResourceData(d, "description", c.Description); err != nil {
+		return fmt.Errorf("error setting description for resource %s: %w", d.Id(), err)
 	}
 	d.Set("activated", c.Activated)
 	d.Set("muted", c.Muted)
@@ -292,7 +290,7 @@ func icmpMonitorFromResourceData(d *schema.ResourceData) (checkly.ICMPMonitor, e
 	monitor := checkly.ICMPMonitor{
 		ID:                          d.Id(),
 		Name:                        d.Get("name").(string),
-		Description:                 d.Get("description").(string),
+		Description:                 optionalStringPointerFromResourceData(d, "description"),
 		Frequency:                   d.Get(frequencyAttributeName).(int),
 		Activated:                   d.Get("activated").(bool),
 		Muted:                       d.Get("muted").(bool),

--- a/checkly/resource_icmp_monitor_test.go
+++ b/checkly/resource_icmp_monitor_test.go
@@ -113,6 +113,64 @@ func TestAccICMPMonitorBasic(t *testing.T) {
 	})
 }
 
+func TestAccICMPMonitorDescriptionRemoval(t *testing.T) {
+	accTestCase(t, []resource.TestStep{
+		{
+			Config: `
+				resource "checkly_icmp_monitor" "test" {
+					name                      = "ICMP Monitor 1"
+					description               = "ICMP monitor description"
+					frequency                 = 60
+					activated                 = true
+					muted                     = true
+					locations                 = ["us-east-1", "eu-central-1"]
+					use_global_alert_settings = true
+
+					request {
+						hostname = "example.com"
+
+						assertion {
+							source     = "LATENCY"
+							property   = "avg"
+							comparison = "LESS_THAN"
+							target     = "200"
+						}
+					}
+				}
+			`,
+			Check: resource.TestCheckResourceAttr(
+				"checkly_icmp_monitor.test",
+				"description",
+				"ICMP monitor description",
+			),
+		},
+		{
+			Config: `
+				resource "checkly_icmp_monitor" "test" {
+					name                      = "ICMP Monitor 1"
+					frequency                 = 60
+					activated                 = true
+					muted                     = true
+					locations                 = ["us-east-1", "eu-central-1"]
+					use_global_alert_settings = true
+
+					request {
+						hostname = "example.com"
+
+						assertion {
+							source     = "LATENCY"
+							property   = "avg"
+							comparison = "LESS_THAN"
+							target     = "200"
+						}
+					}
+				}
+			`,
+			Check: testCheckOptionalAttrRemoved("checkly_icmp_monitor.test", "description"),
+		},
+	})
+}
+
 func TestAccICMPMonitorFull(t *testing.T) {
 	accTestCase(t, []resource.TestStep{
 		{

--- a/checkly/resource_icmp_monitor_test.go
+++ b/checkly/resource_icmp_monitor_test.go
@@ -166,7 +166,11 @@ func TestAccICMPMonitorDescriptionRemoval(t *testing.T) {
 					}
 				}
 			`,
-			Check: testCheckOptionalAttrRemoved("checkly_icmp_monitor.test", "description"),
+			Check: resource.TestCheckResourceAttr(
+				"checkly_icmp_monitor.test",
+				"description",
+				"",
+			),
 		},
 	})
 }

--- a/checkly/resource_icmp_monitor_test.go
+++ b/checkly/resource_icmp_monitor_test.go
@@ -38,6 +38,7 @@ func TestAccICMPMonitorBasic(t *testing.T) {
 			Config: `
 				resource "checkly_icmp_monitor" "test" {
 					name                      = "ICMP Monitor 1"
+					description               = "ICMP monitor description"
 					frequency                 = 60
 					activated                 = true
 					muted                     = true
@@ -61,6 +62,11 @@ func TestAccICMPMonitorBasic(t *testing.T) {
 					"checkly_icmp_monitor.test",
 					"name",
 					"ICMP Monitor 1",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_icmp_monitor.test",
+					"description",
+					"ICMP monitor description",
 				),
 				resource.TestCheckResourceAttr(
 					"checkly_icmp_monitor.test",

--- a/checkly/resource_playwright_check_suite.go
+++ b/checkly/resource_playwright_check_suite.go
@@ -38,6 +38,11 @@ func resourcePlaywrightCheckSuite() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 			},
+			"description": {
+				Description: "A description of the check.",
+				Type:        schema.TypeString,
+				Optional:    true,
+			},
 			frequencyAttributeName: makeFrequencyAttributeSchema(FrequencyAttributeSchemaOptions{
 				Monitor:            false,
 				AllowHighFrequency: false,
@@ -585,6 +590,7 @@ func PlaywrightCheckSuiteResourceFromResourceData(
 	check := checkly.PlaywrightCheck{
 		ID:                        d.Id(),
 		Name:                      d.Get("name").(string),
+		Description:               optionalStringPointerFromResourceData(d, "description"),
 		Frequency:                 d.Get(frequencyAttributeName).(int),
 		Activated:                 d.Get("activated").(bool),
 		Muted:                     d.Get("muted").(bool),
@@ -746,6 +752,7 @@ func (r *PlaywrightCheckSuiteResource) StoreResourceData(
 	d *schema.ResourceData,
 ) error {
 	d.Set("name", r.Name)
+	d.Set("description", r.Description)
 	d.Set("activated", r.Activated)
 	d.Set("muted", r.Muted)
 	d.Set("run_parallel", r.RunParallel)

--- a/checkly/resource_playwright_check_suite_test.go
+++ b/checkly/resource_playwright_check_suite_test.go
@@ -22,6 +22,7 @@ func TestAccPlaywrightCheckSuiteWithEnvironmentVariable(t *testing.T) {
 			Config: playwrightCheckSuiteBase + `
 				resource "checkly_playwright_check_suite" "test" {
 					name                      = "PW Check with env vars"
+					description               = "Playwright check description"
 					activated                 = true
 					frequency                 = 720
 					use_global_alert_settings = true
@@ -67,6 +68,11 @@ func TestAccPlaywrightCheckSuiteWithEnvironmentVariable(t *testing.T) {
 			Check: resource.ComposeTestCheckFunc(
 				resource.TestCheckResourceAttr(
 					"checkly_playwright_check_suite.test",
+					"description",
+					"Playwright check description",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_playwright_check_suite.test",
 					"environment_variable.#",
 					"2",
 				),
@@ -100,6 +106,54 @@ func TestAccPlaywrightCheckSuiteWithEnvironmentVariable(t *testing.T) {
 					"environment_variable.1.locked",
 					"true",
 				),
+			),
+		},
+	})
+}
+
+func TestAccPlaywrightCheckSuiteDescriptionRemoval(t *testing.T) {
+	accTestCase(t, []resource.TestStep{
+		{
+			Config: playwrightCheckSuiteBase + `
+				resource "checkly_playwright_check_suite" "test" {
+					name                      = "PW Check description removal"
+					description               = "Playwright check description"
+					activated                 = true
+					frequency                 = 720
+					use_global_alert_settings = true
+					locations                 = ["us-east-1"]
+
+					bundle {
+						id       = checkly_playwright_code_bundle.test.id
+						metadata = checkly_playwright_code_bundle.test.metadata
+					}
+				}
+			`,
+			Check: resource.TestCheckResourceAttr(
+				"checkly_playwright_check_suite.test",
+				"description",
+				"Playwright check description",
+			),
+		},
+		{
+			Config: playwrightCheckSuiteBase + `
+				resource "checkly_playwright_check_suite" "test" {
+					name                      = "PW Check description removal"
+					activated                 = true
+					frequency                 = 720
+					use_global_alert_settings = true
+					locations                 = ["us-east-1"]
+
+					bundle {
+						id       = checkly_playwright_code_bundle.test.id
+						metadata = checkly_playwright_code_bundle.test.metadata
+					}
+				}
+			`,
+			Check: resource.TestCheckResourceAttr(
+				"checkly_playwright_check_suite.test",
+				"description",
+				"",
 			),
 		},
 	})

--- a/checkly/resource_tcp_monitor.go
+++ b/checkly/resource_tcp_monitor.go
@@ -28,6 +28,11 @@ func resourceTCPMonitor() *schema.Resource {
 				Required:    true,
 				Description: "The name of the check.",
 			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "A description of the check.",
+			},
 			frequencyAttributeName: makeFrequencyAttributeSchema(FrequencyAttributeSchemaOptions{
 				Monitor:            true,
 				AllowHighFrequency: true,
@@ -283,6 +288,7 @@ func resourceTCPMonitorDelete(d *schema.ResourceData, client interface{}) error 
 
 func resourceDataFromTCPMonitor(c *checkly.TCPMonitor, d *schema.ResourceData) error {
 	d.Set("name", c.Name)
+	d.Set("description", c.Description)
 	d.Set("activated", c.Activated)
 	d.Set("muted", c.Muted)
 	d.Set("should_fail", c.ShouldFail)
@@ -338,6 +344,7 @@ func tcpCheckFromResourceData(d *schema.ResourceData) (checkly.TCPMonitor, error
 	monitor := checkly.TCPMonitor{
 		ID:                        d.Id(),
 		Name:                      d.Get("name").(string),
+		Description:               d.Get("description").(string),
 		Frequency:                 d.Get(frequencyAttributeName).(int),
 		Activated:                 d.Get("activated").(bool),
 		Muted:                     d.Get("muted").(bool),

--- a/checkly/resource_tcp_monitor.go
+++ b/checkly/resource_tcp_monitor.go
@@ -31,7 +31,7 @@ func resourceTCPMonitor() *schema.Resource {
 			"description": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: "A description of the check.",
+				Description: "A description of the monitor.",
 			},
 			frequencyAttributeName: makeFrequencyAttributeSchema(FrequencyAttributeSchemaOptions{
 				Monitor:            true,

--- a/checkly/resource_tcp_monitor.go
+++ b/checkly/resource_tcp_monitor.go
@@ -288,9 +288,7 @@ func resourceTCPMonitorDelete(d *schema.ResourceData, client interface{}) error 
 
 func resourceDataFromTCPMonitor(c *checkly.TCPMonitor, d *schema.ResourceData) error {
 	d.Set("name", c.Name)
-	if err := setOptionalStringResourceData(d, "description", c.Description); err != nil {
-		return fmt.Errorf("error setting description for resource %s: %w", d.Id(), err)
-	}
+	d.Set("description", c.Description)
 	d.Set("activated", c.Activated)
 	d.Set("muted", c.Muted)
 	d.Set("should_fail", c.ShouldFail)

--- a/checkly/resource_tcp_monitor.go
+++ b/checkly/resource_tcp_monitor.go
@@ -288,10 +288,8 @@ func resourceTCPMonitorDelete(d *schema.ResourceData, client interface{}) error 
 
 func resourceDataFromTCPMonitor(c *checkly.TCPMonitor, d *schema.ResourceData) error {
 	d.Set("name", c.Name)
-	if c.Description == "" {
-		d.Set("description", nil)
-	} else {
-		d.Set("description", c.Description)
+	if err := setOptionalStringResourceData(d, "description", c.Description); err != nil {
+		return fmt.Errorf("error setting description for resource %s: %w", d.Id(), err)
 	}
 	d.Set("activated", c.Activated)
 	d.Set("muted", c.Muted)
@@ -348,7 +346,7 @@ func tcpCheckFromResourceData(d *schema.ResourceData) (checkly.TCPMonitor, error
 	monitor := checkly.TCPMonitor{
 		ID:                        d.Id(),
 		Name:                      d.Get("name").(string),
-		Description:               d.Get("description").(string),
+		Description:               optionalStringPointerFromResourceData(d, "description"),
 		Frequency:                 d.Get(frequencyAttributeName).(int),
 		Activated:                 d.Get("activated").(bool),
 		Muted:                     d.Get("muted").(bool),

--- a/checkly/resource_tcp_monitor.go
+++ b/checkly/resource_tcp_monitor.go
@@ -288,7 +288,11 @@ func resourceTCPMonitorDelete(d *schema.ResourceData, client interface{}) error 
 
 func resourceDataFromTCPMonitor(c *checkly.TCPMonitor, d *schema.ResourceData) error {
 	d.Set("name", c.Name)
-	d.Set("description", c.Description)
+	if c.Description == "" {
+		d.Set("description", nil)
+	} else {
+		d.Set("description", c.Description)
+	}
 	d.Set("activated", c.Activated)
 	d.Set("muted", c.Muted)
 	d.Set("should_fail", c.ShouldFail)

--- a/checkly/resource_tcp_monitor_test.go
+++ b/checkly/resource_tcp_monitor_test.go
@@ -109,7 +109,11 @@ func TestAccTCPMonitorDescriptionRemoval(t *testing.T) {
 		},
 		{
 			Config: tcpMonitor_basic_withoutDescription,
-			Check:  testCheckOptionalAttrRemoved("checkly_tcp_monitor.test", "description"),
+			Check: resource.TestCheckResourceAttr(
+				"checkly_tcp_monitor.test",
+				"description",
+				"",
+			),
 		},
 	})
 }

--- a/checkly/resource_tcp_monitor_test.go
+++ b/checkly/resource_tcp_monitor_test.go
@@ -97,6 +97,23 @@ func TestAccTCPMonitorBasic(t *testing.T) {
 	})
 }
 
+func TestAccTCPMonitorDescriptionRemoval(t *testing.T) {
+	accTestCase(t, []resource.TestStep{
+		{
+			Config: tcpMonitor_basic,
+			Check: resource.TestCheckResourceAttr(
+				"checkly_tcp_monitor.test",
+				"description",
+				"TCP monitor description",
+			),
+		},
+		{
+			Config: tcpMonitor_basic_withoutDescription,
+			Check:  testCheckOptionalAttrRemoved("checkly_tcp_monitor.test", "description"),
+		},
+	})
+}
+
 func TestAccTCPMonitorFull(t *testing.T) {
 	accTestCase(t, []resource.TestStep{
 		{
@@ -280,6 +297,28 @@ const tcpMonitor_basic = `
 	resource "checkly_tcp_monitor" "test" {
 	  name                      = "TCP Monitor 1"
 	  description               = "TCP monitor description"
+	  frequency                 = 60
+	  activated                 = true
+	  muted                     = true
+	  max_response_time         = 3000
+	  locations                 = [ "us-east-1", "eu-central-1" ]
+	  use_global_alert_settings = true
+	  request {
+		hostname     = "api.checklyhq.com"
+		port         = 80
+		assertion {
+		  comparison = "LESS_THAN"
+		  property   = ""
+		  source     = "RESPONSE_TIME"
+		  target     = "2000"
+		}
+	  }
+	}
+`
+
+const tcpMonitor_basic_withoutDescription = `
+	resource "checkly_tcp_monitor" "test" {
+	  name                      = "TCP Monitor 1"
 	  frequency                 = 60
 	  activated                 = true
 	  muted                     = true

--- a/checkly/resource_tcp_monitor_test.go
+++ b/checkly/resource_tcp_monitor_test.go
@@ -44,6 +44,11 @@ func TestAccTCPMonitorBasic(t *testing.T) {
 				),
 				resource.TestCheckResourceAttr(
 					"checkly_tcp_monitor.test",
+					"description",
+					"TCP monitor description",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_tcp_monitor.test",
 					"activated",
 					"true",
 				),
@@ -274,6 +279,7 @@ func TestEncodeDecodeTCPMonitorResource(t *testing.T) {
 const tcpMonitor_basic = `
 	resource "checkly_tcp_monitor" "test" {
 	  name                      = "TCP Monitor 1"
+	  description               = "TCP monitor description"
 	  frequency                 = 60
 	  activated                 = true
 	  muted                     = true

--- a/checkly/resource_url_monitor.go
+++ b/checkly/resource_url_monitor.go
@@ -28,6 +28,11 @@ func resourceURLMonitor() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 			},
+			"description": {
+				Description: "A description of the monitor.",
+				Type:        schema.TypeString,
+				Optional:    true,
+			},
 			frequencyAttributeName: makeFrequencyAttributeSchema(FrequencyAttributeSchemaOptions{
 				Monitor:            true,
 				AllowHighFrequency: true,
@@ -262,6 +267,7 @@ func resourceURLMonitorDelete(d *schema.ResourceData, client interface{}) error 
 
 func resourceDataFromURLMonitor(c *checkly.URLMonitor, d *schema.ResourceData) error {
 	d.Set("name", c.Name)
+	d.Set("description", c.Description)
 	d.Set("activated", c.Activated)
 	d.Set("muted", c.Muted)
 	d.Set("should_fail", c.ShouldFail)
@@ -303,6 +309,7 @@ func urlMonitorFromResourceData(d *schema.ResourceData) (checkly.URLMonitor, err
 	check := checkly.URLMonitor{
 		ID:                        d.Id(),
 		Name:                      d.Get("name").(string),
+		Description:               d.Get("description").(string),
 		Frequency:                 d.Get(frequencyAttributeName).(int),
 		Activated:                 d.Get("activated").(bool),
 		Muted:                     d.Get("muted").(bool),

--- a/checkly/resource_url_monitor.go
+++ b/checkly/resource_url_monitor.go
@@ -267,7 +267,11 @@ func resourceURLMonitorDelete(d *schema.ResourceData, client interface{}) error 
 
 func resourceDataFromURLMonitor(c *checkly.URLMonitor, d *schema.ResourceData) error {
 	d.Set("name", c.Name)
-	d.Set("description", c.Description)
+	if c.Description == "" {
+		d.Set("description", nil)
+	} else {
+		d.Set("description", c.Description)
+	}
 	d.Set("activated", c.Activated)
 	d.Set("muted", c.Muted)
 	d.Set("should_fail", c.ShouldFail)

--- a/checkly/resource_url_monitor.go
+++ b/checkly/resource_url_monitor.go
@@ -267,10 +267,8 @@ func resourceURLMonitorDelete(d *schema.ResourceData, client interface{}) error 
 
 func resourceDataFromURLMonitor(c *checkly.URLMonitor, d *schema.ResourceData) error {
 	d.Set("name", c.Name)
-	if c.Description == "" {
-		d.Set("description", nil)
-	} else {
-		d.Set("description", c.Description)
+	if err := setOptionalStringResourceData(d, "description", c.Description); err != nil {
+		return fmt.Errorf("error setting description for resource %s: %w", d.Id(), err)
 	}
 	d.Set("activated", c.Activated)
 	d.Set("muted", c.Muted)
@@ -313,7 +311,7 @@ func urlMonitorFromResourceData(d *schema.ResourceData) (checkly.URLMonitor, err
 	check := checkly.URLMonitor{
 		ID:                        d.Id(),
 		Name:                      d.Get("name").(string),
-		Description:               d.Get("description").(string),
+		Description:               optionalStringPointerFromResourceData(d, "description"),
 		Frequency:                 d.Get(frequencyAttributeName).(int),
 		Activated:                 d.Get("activated").(bool),
 		Muted:                     d.Get("muted").(bool),

--- a/checkly/resource_url_monitor.go
+++ b/checkly/resource_url_monitor.go
@@ -267,9 +267,7 @@ func resourceURLMonitorDelete(d *schema.ResourceData, client interface{}) error 
 
 func resourceDataFromURLMonitor(c *checkly.URLMonitor, d *schema.ResourceData) error {
 	d.Set("name", c.Name)
-	if err := setOptionalStringResourceData(d, "description", c.Description); err != nil {
-		return fmt.Errorf("error setting description for resource %s: %w", d.Id(), err)
-	}
+	d.Set("description", c.Description)
 	d.Set("activated", c.Activated)
 	d.Set("muted", c.Muted)
 	d.Set("should_fail", c.ShouldFail)

--- a/checkly/resource_url_monitor_test.go
+++ b/checkly/resource_url_monitor_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/checkly/checkly-go-sdk"
 )
@@ -107,10 +108,17 @@ func TestAccURLMonitorDescriptionRemoval(t *testing.T) {
 		{
 			Config: urlMonitor_basic_withoutDescription,
 			Check: resource.ComposeTestCheckFunc(
-				resource.TestCheckNoResourceAttr(
-					"checkly_url_monitor.test",
-					"description",
-				),
+				func(s *terraform.State) error {
+					value, ok := s.Modules[0].Resources["checkly_url_monitor.test"].Primary.Attributes["description"]
+					if !ok || value == "" {
+						return nil
+					}
+
+					return resource.TestCheckNoResourceAttr(
+						"checkly_url_monitor.test",
+						"description",
+					)(s)
+				},
 			),
 		},
 	})

--- a/checkly/resource_url_monitor_test.go
+++ b/checkly/resource_url_monitor_test.go
@@ -44,6 +44,11 @@ func TestAccURLMonitorBasic(t *testing.T) {
 				),
 				resource.TestCheckResourceAttr(
 					"checkly_url_monitor.test",
+					"description",
+					"URL monitor description",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_url_monitor.test",
 					"activated",
 					"true",
 				),
@@ -81,6 +86,30 @@ func TestAccURLMonitorBasic(t *testing.T) {
 					"checkly_url_monitor.test",
 					"request.*.assertion.*.target",
 					"200",
+				),
+			),
+		},
+	})
+}
+
+func TestAccURLMonitorDescriptionRemoval(t *testing.T) {
+	accTestCase(t, []resource.TestStep{
+		{
+			Config: urlMonitor_basic,
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr(
+					"checkly_url_monitor.test",
+					"description",
+					"URL monitor description",
+				),
+			),
+		},
+		{
+			Config: urlMonitor_basic_withoutDescription,
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckNoResourceAttr(
+					"checkly_url_monitor.test",
+					"description",
 				),
 			),
 		},
@@ -284,6 +313,28 @@ func TestEncodeDecodeURLMonitorResource(t *testing.T) {
 }
 
 const urlMonitor_basic = `
+resource "checkly_url_monitor" "test" {
+  name                      = "URL Monitor 1"
+  description               = "URL monitor description"
+  frequency                 = 60
+  activated                 = true
+  muted                     = true
+  max_response_time         = 3000
+  locations                 = ["us-east-1", "eu-central-1"]
+  use_global_alert_settings = true
+  request {
+    url = "https://api.checklyhq.com"
+    assertion {
+      comparison = "EQUALS"
+      property   = ""
+      source     = "STATUS_CODE"
+      target     = "200"
+    }
+  }
+}
+`
+
+const urlMonitor_basic_withoutDescription = `
 resource "checkly_url_monitor" "test" {
   name                      = "URL Monitor 1"
   frequency                 = 60

--- a/checkly/resource_url_monitor_test.go
+++ b/checkly/resource_url_monitor_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/checkly/checkly-go-sdk"
 )
@@ -108,17 +107,10 @@ func TestAccURLMonitorDescriptionRemoval(t *testing.T) {
 		{
 			Config: urlMonitor_basic_withoutDescription,
 			Check: resource.ComposeTestCheckFunc(
-				func(s *terraform.State) error {
-					value, ok := s.Modules[0].Resources["checkly_url_monitor.test"].Primary.Attributes["description"]
-					if !ok || value == "" {
-						return nil
-					}
-
-					return resource.TestCheckNoResourceAttr(
-						"checkly_url_monitor.test",
-						"description",
-					)(s)
-				},
+				resource.TestCheckNoResourceAttr(
+					"checkly_url_monitor.test",
+					"description",
+				),
 			),
 		},
 	})

--- a/checkly/resource_url_monitor_test.go
+++ b/checkly/resource_url_monitor_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/checkly/checkly-go-sdk"
 )
@@ -107,19 +106,7 @@ func TestAccURLMonitorDescriptionRemoval(t *testing.T) {
 		},
 		{
 			Config: urlMonitor_basic_withoutDescription,
-			Check: resource.ComposeTestCheckFunc(
-				func(s *terraform.State) error {
-					value, ok := s.Modules[0].Resources["checkly_url_monitor.test"].Primary.Attributes["description"]
-					if !ok || value == "" {
-						return nil
-					}
-
-					return resource.TestCheckNoResourceAttr(
-						"checkly_url_monitor.test",
-						"description",
-					)(s)
-				},
-			),
+			Check:  testCheckOptionalAttrRemoved("checkly_url_monitor.test", "description"),
 		},
 	})
 }

--- a/checkly/resource_url_monitor_test.go
+++ b/checkly/resource_url_monitor_test.go
@@ -106,7 +106,11 @@ func TestAccURLMonitorDescriptionRemoval(t *testing.T) {
 		},
 		{
 			Config: urlMonitor_basic_withoutDescription,
-			Check:  testCheckOptionalAttrRemoved("checkly_url_monitor.test", "description"),
+			Check: resource.TestCheckResourceAttr(
+				"checkly_url_monitor.test",
+				"description",
+				"",
+			),
 		},
 	})
 }

--- a/checkly/test_util.go
+++ b/checkly/test_util.go
@@ -63,20 +63,3 @@ func testCheckResourceAttrExpr(resource, attrExpr, value string) func(s *terrafo
 		return err
 	}
 }
-
-// testCheckOptionalAttrRemoved asserts that an optional attribute is either
-// absent from state or empty — the expected shape after a user removes an
-// Optional string field from their Terraform config.
-func testCheckOptionalAttrRemoved(resourceName, attr string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		res, ok := s.Modules[0].Resources[resourceName]
-		if !ok {
-			return fmt.Errorf("Resource not found: %s", resourceName)
-		}
-		value, present := res.Primary.Attributes[attr]
-		if !present || value == "" {
-			return nil
-		}
-		return resource.TestCheckNoResourceAttr(resourceName, attr)(s)
-	}
-}

--- a/checkly/test_util.go
+++ b/checkly/test_util.go
@@ -63,3 +63,20 @@ func testCheckResourceAttrExpr(resource, attrExpr, value string) func(s *terrafo
 		return err
 	}
 }
+
+// testCheckOptionalAttrRemoved asserts that an optional attribute is either
+// absent from state or empty — the expected shape after a user removes an
+// Optional string field from their Terraform config.
+func testCheckOptionalAttrRemoved(resourceName, attr string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		res, ok := s.Modules[0].Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Resource not found: %s", resourceName)
+		}
+		value, present := res.Primary.Attributes[attr]
+		if !present || value == "" {
+			return nil
+		}
+		return resource.TestCheckNoResourceAttr(resourceName, attr)(s)
+	}
+}

--- a/docs/resources/check.md
+++ b/docs/resources/check.md
@@ -199,6 +199,7 @@ resource "checkly_check" "example_check" {
 - `alert_channel_subscription` (Block Set) An array of channel IDs and whether they're activated or not. If you don't set at least one alert channel subscription for your check, we won't be able to alert you even if it starts failing. (see [below for nested schema](#nestedblock--alert_channel_subscription))
 - `alert_settings` (Block List, Max: 1) Determines the alert escalation policy for the check. (see [below for nested schema](#nestedblock--alert_settings))
 - `degraded_response_time` (Number) The response time in milliseconds starting from which a check should be considered degraded. Possible values are between 0 and 30000. (Default `15000`).
+- `description` (String) A description of the check.
 - `double_check` (Boolean, Deprecated) Setting this to `true` will trigger a retry when a check fails from the failing region and another, randomly selected region before marking the check as failed. (Default `false`).
 - `environment_variable` (Block List) Insert environment variables into the runtime environment. Only relevant for browser checks. Use global environment variables whenever possible. (see [below for nested schema](#nestedblock--environment_variable))
 - `environment_variables` (Map of String, Deprecated) Key/value pairs of environment variables to insert into the runtime environment.

--- a/docs/resources/dns_monitor.md
+++ b/docs/resources/dns_monitor.md
@@ -56,6 +56,7 @@ resource "checkly_dns_monitor" "example-dns-monitor" {
 - `alert_channel_subscription` (Block Set) An array of channel IDs and whether they're activated or not. If you don't set at least one alert channel subscription for your monitor, we won't be able to alert you even if it starts failing. (see [below for nested schema](#nestedblock--alert_channel_subscription))
 - `alert_settings` (Block List, Max: 1) Determines the alert escalation policy for the monitor. (see [below for nested schema](#nestedblock--alert_settings))
 - `degraded_response_time` (Number) The response time in milliseconds where the monitor should be considered degraded. Possible values are between `0` and `5000`. (Default `500`).
+- `description` (String) A description of the monitor.
 - `frequency_offset` (Number) When `frequency` is `0` (high frequency), `frequency_offset` is required and it alone controls how often the monitor should run. Defined in seconds. The allowed values are `0` (disabled - use `frequency` to define the actual frequency), `10` (10 seconds), `20` (20 seconds) and `30` (30 seconds).
 - `group_id` (Number) The ID of the check group that this monitor is part of.
 - `group_order` (Number) The position of the monitor in the check group. It determines in what order checks and monitors are run when a group is triggered from the API or from CI/CD.

--- a/docs/resources/heartbeat.md
+++ b/docs/resources/heartbeat.md
@@ -45,6 +45,7 @@ resource "checkly_heartbeat" "example-heartbeat" {
 
 - `alert_channel_subscription` (Block Set) An array of channel IDs and whether they're activated or not. If you don't set at least one alert channel subscription for your monitor, we won't be able to alert you even if it starts failing. (see [below for nested schema](#nestedblock--alert_channel_subscription))
 - `alert_settings` (Block List, Max: 1) Determines the alert escalation policy for the monitor. (see [below for nested schema](#nestedblock--alert_settings))
+- `description` (String) A description of the check.
 - `muted` (Boolean) Determines if any notifications will be sent out when a check fails/degrades/recovers.
 - `tags` (Set of String) A list of tags for organizing and filtering checks.
 - `trigger_incident` (Block Set, Max: 1) Create and resolve an incident based on the alert configuration. Useful for status page automation. (see [below for nested schema](#nestedblock--trigger_incident))

--- a/docs/resources/heartbeat.md
+++ b/docs/resources/heartbeat.md
@@ -45,7 +45,7 @@ resource "checkly_heartbeat" "example-heartbeat" {
 
 - `alert_channel_subscription` (Block Set) An array of channel IDs and whether they're activated or not. If you don't set at least one alert channel subscription for your monitor, we won't be able to alert you even if it starts failing. (see [below for nested schema](#nestedblock--alert_channel_subscription))
 - `alert_settings` (Block List, Max: 1) Determines the alert escalation policy for the monitor. (see [below for nested schema](#nestedblock--alert_settings))
-- `description` (String) A description of the check.
+- `description` (String) A description of the monitor.
 - `muted` (Boolean) Determines if any notifications will be sent out when a check fails/degrades/recovers.
 - `tags` (Set of String) A list of tags for organizing and filtering checks.
 - `trigger_incident` (Block Set, Max: 1) Create and resolve an incident based on the alert configuration. Useful for status page automation. (see [below for nested schema](#nestedblock--trigger_incident))

--- a/docs/resources/heartbeat_monitor.md
+++ b/docs/resources/heartbeat_monitor.md
@@ -39,7 +39,7 @@ resource "checkly_heartbeat_monitor" "example-heartbeat-monitor" {
 
 - `alert_channel_subscription` (Block Set) An array of channel IDs and whether they're activated or not. If you don't set at least one alert channel subscription for your monitor, we won't be able to alert you even if it starts failing. (see [below for nested schema](#nestedblock--alert_channel_subscription))
 - `alert_settings` (Block List, Max: 1) Determines the alert escalation policy for the monitor. (see [below for nested schema](#nestedblock--alert_settings))
-- `description` (String) A description of the check.
+- `description` (String) A description of the monitor.
 - `muted` (Boolean) Determines if any notifications will be sent out when a check fails/degrades/recovers.
 - `tags` (Set of String) A list of tags for organizing and filtering checks.
 - `trigger_incident` (Block Set, Max: 1) Create and resolve an incident based on the alert configuration. Useful for status page automation. (see [below for nested schema](#nestedblock--trigger_incident))

--- a/docs/resources/heartbeat_monitor.md
+++ b/docs/resources/heartbeat_monitor.md
@@ -39,6 +39,7 @@ resource "checkly_heartbeat_monitor" "example-heartbeat-monitor" {
 
 - `alert_channel_subscription` (Block Set) An array of channel IDs and whether they're activated or not. If you don't set at least one alert channel subscription for your monitor, we won't be able to alert you even if it starts failing. (see [below for nested schema](#nestedblock--alert_channel_subscription))
 - `alert_settings` (Block List, Max: 1) Determines the alert escalation policy for the monitor. (see [below for nested schema](#nestedblock--alert_settings))
+- `description` (String) A description of the check.
 - `muted` (Boolean) Determines if any notifications will be sent out when a check fails/degrades/recovers.
 - `tags` (Set of String) A list of tags for organizing and filtering checks.
 - `trigger_incident` (Block Set, Max: 1) Create and resolve an incident based on the alert configuration. Useful for status page automation. (see [below for nested schema](#nestedblock--trigger_incident))

--- a/docs/resources/icmp_monitor.md
+++ b/docs/resources/icmp_monitor.md
@@ -53,6 +53,7 @@ resource "checkly_icmp_monitor" "example-icmp-monitor" {
 - `alert_channel_subscription` (Block Set) An array of channel IDs and whether they're activated or not. If you don't set at least one alert channel subscription for your monitor, we won't be able to alert you even if it starts failing. (see [below for nested schema](#nestedblock--alert_channel_subscription))
 - `alert_settings` (Block List, Max: 1) Determines the alert escalation policy for the monitor. (see [below for nested schema](#nestedblock--alert_settings))
 - `degraded_packet_loss_threshold` (Number) The packet loss percentage where the monitor should be considered degraded. Possible values are between `0` and `100`. (Default `10`).
+- `description` (String) A description of the monitor.
 - `frequency_offset` (Number) When `frequency` is `0` (high frequency), `frequency_offset` is required and it alone controls how often the monitor should run. Defined in seconds. The allowed values are `0` (disabled - use `frequency` to define the actual frequency), `10` (10 seconds), `20` (20 seconds) and `30` (30 seconds).
 - `group_id` (Number) The ID of the check group that this monitor is part of.
 - `group_order` (Number) The position of the monitor in the check group. It determines in what order checks and monitors are run when a group is triggered from the API or from CI/CD.

--- a/docs/resources/playwright_check_suite.md
+++ b/docs/resources/playwright_check_suite.md
@@ -129,6 +129,7 @@ resource "checkly_playwright_check_suite" "example-playwright-check-custom" {
 
 - `alert_channel_subscription` (Block Set) An array of channel IDs and whether they're activated or not. If you don't set at least one alert channel subscription for your check, we won't be able to alert you even if it starts failing. (see [below for nested schema](#nestedblock--alert_channel_subscription))
 - `alert_settings` (Block List, Max: 1) Determines the alert escalation policy for the check. (see [below for nested schema](#nestedblock--alert_settings))
+- `description` (String) A description of the check.
 - `environment_variable` (Block List) Insert environment variables into the execution environment. (see [below for nested schema](#nestedblock--environment_variable))
 - `group_id` (Number) The ID of the check group that this check is part of.
 - `group_order` (Number) The position of the check in the check group. It determines in what order checks and monitors are run when a group is triggered from the API or from CI/CD.

--- a/docs/resources/tcp_check.md
+++ b/docs/resources/tcp_check.md
@@ -109,7 +109,7 @@ resource "checkly_tcp_check" "example-tcp-check-2" {
 - `alert_channel_subscription` (Block Set) An array of channel IDs and whether they're activated or not. If you don't set at least one alert channel subscription for your monitor, we won't be able to alert you even if it starts failing. (see [below for nested schema](#nestedblock--alert_channel_subscription))
 - `alert_settings` (Block List, Max: 1) Determines the alert escalation policy for the monitor. (see [below for nested schema](#nestedblock--alert_settings))
 - `degraded_response_time` (Number) The response time in milliseconds starting from which a check should be considered degraded. Possible values are between 0 and 5000. (Default `4000`).
-- `description` (String) A description of the check.
+- `description` (String) A description of the monitor.
 - `frequency_offset` (Number) When `frequency` is `0` (high frequency), `frequency_offset` is required and it alone controls how often the monitor should run. Defined in seconds. The allowed values are `0` (disabled - use `frequency` to define the actual frequency), `10` (10 seconds), `20` (20 seconds) and `30` (30 seconds).
 - `group_id` (Number) The id of the check group this check is part of.
 - `group_order` (Number) The position of this check in a check group. It determines in what order checks are run when a group is triggered from the API or from CI/CD.

--- a/docs/resources/tcp_check.md
+++ b/docs/resources/tcp_check.md
@@ -109,6 +109,7 @@ resource "checkly_tcp_check" "example-tcp-check-2" {
 - `alert_channel_subscription` (Block Set) An array of channel IDs and whether they're activated or not. If you don't set at least one alert channel subscription for your monitor, we won't be able to alert you even if it starts failing. (see [below for nested schema](#nestedblock--alert_channel_subscription))
 - `alert_settings` (Block List, Max: 1) Determines the alert escalation policy for the monitor. (see [below for nested schema](#nestedblock--alert_settings))
 - `degraded_response_time` (Number) The response time in milliseconds starting from which a check should be considered degraded. Possible values are between 0 and 5000. (Default `4000`).
+- `description` (String) A description of the check.
 - `frequency_offset` (Number) When `frequency` is `0` (high frequency), `frequency_offset` is required and it alone controls how often the monitor should run. Defined in seconds. The allowed values are `0` (disabled - use `frequency` to define the actual frequency), `10` (10 seconds), `20` (20 seconds) and `30` (30 seconds).
 - `group_id` (Number) The id of the check group this check is part of.
 - `group_order` (Number) The position of this check in a check group. It determines in what order checks are run when a group is triggered from the API or from CI/CD.

--- a/docs/resources/tcp_monitor.md
+++ b/docs/resources/tcp_monitor.md
@@ -103,7 +103,7 @@ resource "checkly_tcp_monitor" "example-tcp-monitor-2" {
 - `alert_channel_subscription` (Block Set) An array of channel IDs and whether they're activated or not. If you don't set at least one alert channel subscription for your monitor, we won't be able to alert you even if it starts failing. (see [below for nested schema](#nestedblock--alert_channel_subscription))
 - `alert_settings` (Block List, Max: 1) Determines the alert escalation policy for the monitor. (see [below for nested schema](#nestedblock--alert_settings))
 - `degraded_response_time` (Number) The response time in milliseconds starting from which a check should be considered degraded. Possible values are between 0 and 5000. (Default `4000`).
-- `description` (String) A description of the check.
+- `description` (String) A description of the monitor.
 - `frequency_offset` (Number) When `frequency` is `0` (high frequency), `frequency_offset` is required and it alone controls how often the monitor should run. Defined in seconds. The allowed values are `0` (disabled - use `frequency` to define the actual frequency), `10` (10 seconds), `20` (20 seconds) and `30` (30 seconds).
 - `group_id` (Number) The id of the check group this check is part of.
 - `group_order` (Number) The position of this check in a check group. It determines in what order checks are run when a group is triggered from the API or from CI/CD.

--- a/docs/resources/tcp_monitor.md
+++ b/docs/resources/tcp_monitor.md
@@ -103,6 +103,7 @@ resource "checkly_tcp_monitor" "example-tcp-monitor-2" {
 - `alert_channel_subscription` (Block Set) An array of channel IDs and whether they're activated or not. If you don't set at least one alert channel subscription for your monitor, we won't be able to alert you even if it starts failing. (see [below for nested schema](#nestedblock--alert_channel_subscription))
 - `alert_settings` (Block List, Max: 1) Determines the alert escalation policy for the monitor. (see [below for nested schema](#nestedblock--alert_settings))
 - `degraded_response_time` (Number) The response time in milliseconds starting from which a check should be considered degraded. Possible values are between 0 and 5000. (Default `4000`).
+- `description` (String) A description of the check.
 - `frequency_offset` (Number) When `frequency` is `0` (high frequency), `frequency_offset` is required and it alone controls how often the monitor should run. Defined in seconds. The allowed values are `0` (disabled - use `frequency` to define the actual frequency), `10` (10 seconds), `20` (20 seconds) and `30` (30 seconds).
 - `group_id` (Number) The id of the check group this check is part of.
 - `group_order` (Number) The position of this check in a check group. It determines in what order checks are run when a group is triggered from the API or from CI/CD.

--- a/docs/resources/url_monitor.md
+++ b/docs/resources/url_monitor.md
@@ -50,6 +50,7 @@ resource "checkly_url_monitor" "example-url-monitor" {
 - `alert_channel_subscription` (Block Set) An array of channel IDs and whether they're activated or not. If you don't set at least one alert channel subscription for your monitor, we won't be able to alert you even if it starts failing. (see [below for nested schema](#nestedblock--alert_channel_subscription))
 - `alert_settings` (Block List, Max: 1) Determines the alert escalation policy for the monitor. (see [below for nested schema](#nestedblock--alert_settings))
 - `degraded_response_time` (Number) The response time in milliseconds where the monitor should be considered degraded. Possible values are between `0` and `30000`. (Default `3000`).
+- `description` (String) A description of the monitor.
 - `frequency_offset` (Number) When `frequency` is `0` (high frequency), `frequency_offset` is required and it alone controls how often the monitor should run. Defined in seconds. The allowed values are `0` (disabled - use `frequency` to define the actual frequency), `10` (10 seconds), `20` (20 seconds) and `30` (30 seconds).
 - `group_id` (Number) The ID of the check group that this monitor is part of.
 - `group_order` (Number) The position of the monitor in the check group. It determines in what order checks and monitors are run when a group is triggered from the API or from CI/CD.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.8
 
 require (
 	github.com/aws/aws-sdk-go v1.44.122 // indirect
-	github.com/checkly/checkly-go-sdk v1.20.2-0.20260415212647-51d604962319
+	github.com/checkly/checkly-go-sdk v1.20.2
 	github.com/google/go-cmp v0.7.0
 	github.com/gruntwork-io/terratest v0.41.16
 	github.com/hashicorp/terraform-plugin-docs v0.25.0

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.8
 
 require (
 	github.com/aws/aws-sdk-go v1.44.122 // indirect
-	github.com/checkly/checkly-go-sdk v1.20.1
+	github.com/checkly/checkly-go-sdk v1.20.2-0.20260414145647-c05d19a329b5
 	github.com/google/go-cmp v0.7.0
 	github.com/gruntwork-io/terratest v0.41.16
 	github.com/hashicorp/terraform-plugin-docs v0.25.0

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.8
 
 require (
 	github.com/aws/aws-sdk-go v1.44.122 // indirect
-	github.com/checkly/checkly-go-sdk v1.20.2-0.20260414145647-c05d19a329b5
+	github.com/checkly/checkly-go-sdk v1.20.2-0.20260415212647-51d604962319
 	github.com/google/go-cmp v0.7.0
 	github.com/gruntwork-io/terratest v0.41.16
 	github.com/hashicorp/terraform-plugin-docs v0.25.0

--- a/go.sum
+++ b/go.sum
@@ -253,6 +253,10 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/checkly/checkly-go-sdk v1.20.1 h1:mbORCp15BBKgXKBL1IgSoQ+RFg01Tlyvy/T+v6x2hlc=
 github.com/checkly/checkly-go-sdk v1.20.1/go.mod h1:Pd6tBOggAe41NnCU5KwqA8JvD6J20/IctszT2E0AvHo=
+github.com/checkly/checkly-go-sdk v1.20.2-0.20260410080338-8bdef9c3e0b6 h1:WdKLGWwRJmh3s2YhOfs5CX9EZwxbuc1qhFic4YPKSQU=
+github.com/checkly/checkly-go-sdk v1.20.2-0.20260410080338-8bdef9c3e0b6/go.mod h1:Pd6tBOggAe41NnCU5KwqA8JvD6J20/IctszT2E0AvHo=
+github.com/checkly/checkly-go-sdk v1.20.2-0.20260414145647-c05d19a329b5 h1:72tQjfJ0wiarGJggMXrPpmPAuxEgSVB8IDJuwhtfSIQ=
+github.com/checkly/checkly-go-sdk v1.20.2-0.20260414145647-c05d19a329b5/go.mod h1:Pd6tBOggAe41NnCU5KwqA8JvD6J20/IctszT2E0AvHo=
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=

--- a/go.sum
+++ b/go.sum
@@ -257,6 +257,8 @@ github.com/checkly/checkly-go-sdk v1.20.2-0.20260410080338-8bdef9c3e0b6 h1:WdKLG
 github.com/checkly/checkly-go-sdk v1.20.2-0.20260410080338-8bdef9c3e0b6/go.mod h1:Pd6tBOggAe41NnCU5KwqA8JvD6J20/IctszT2E0AvHo=
 github.com/checkly/checkly-go-sdk v1.20.2-0.20260414145647-c05d19a329b5 h1:72tQjfJ0wiarGJggMXrPpmPAuxEgSVB8IDJuwhtfSIQ=
 github.com/checkly/checkly-go-sdk v1.20.2-0.20260414145647-c05d19a329b5/go.mod h1:Pd6tBOggAe41NnCU5KwqA8JvD6J20/IctszT2E0AvHo=
+github.com/checkly/checkly-go-sdk v1.20.2-0.20260415212647-51d604962319 h1:LXkLf+zXQHNYn9CZxAg2xx053OivQjMFra3Vu2WaFPE=
+github.com/checkly/checkly-go-sdk v1.20.2-0.20260415212647-51d604962319/go.mod h1:Pd6tBOggAe41NnCU5KwqA8JvD6J20/IctszT2E0AvHo=
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=

--- a/go.sum
+++ b/go.sum
@@ -251,12 +251,6 @@ github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghf
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/checkly/checkly-go-sdk v1.20.1 h1:mbORCp15BBKgXKBL1IgSoQ+RFg01Tlyvy/T+v6x2hlc=
-github.com/checkly/checkly-go-sdk v1.20.1/go.mod h1:Pd6tBOggAe41NnCU5KwqA8JvD6J20/IctszT2E0AvHo=
-github.com/checkly/checkly-go-sdk v1.20.2-0.20260410080338-8bdef9c3e0b6 h1:WdKLGWwRJmh3s2YhOfs5CX9EZwxbuc1qhFic4YPKSQU=
-github.com/checkly/checkly-go-sdk v1.20.2-0.20260410080338-8bdef9c3e0b6/go.mod h1:Pd6tBOggAe41NnCU5KwqA8JvD6J20/IctszT2E0AvHo=
-github.com/checkly/checkly-go-sdk v1.20.2-0.20260414145647-c05d19a329b5 h1:72tQjfJ0wiarGJggMXrPpmPAuxEgSVB8IDJuwhtfSIQ=
-github.com/checkly/checkly-go-sdk v1.20.2-0.20260414145647-c05d19a329b5/go.mod h1:Pd6tBOggAe41NnCU5KwqA8JvD6J20/IctszT2E0AvHo=
 github.com/checkly/checkly-go-sdk v1.20.2-0.20260415212647-51d604962319 h1:LXkLf+zXQHNYn9CZxAg2xx053OivQjMFra3Vu2WaFPE=
 github.com/checkly/checkly-go-sdk v1.20.2-0.20260415212647-51d604962319/go.mod h1:Pd6tBOggAe41NnCU5KwqA8JvD6J20/IctszT2E0AvHo=
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=

--- a/go.sum
+++ b/go.sum
@@ -251,8 +251,8 @@ github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghf
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/checkly/checkly-go-sdk v1.20.2-0.20260415212647-51d604962319 h1:LXkLf+zXQHNYn9CZxAg2xx053OivQjMFra3Vu2WaFPE=
-github.com/checkly/checkly-go-sdk v1.20.2-0.20260415212647-51d604962319/go.mod h1:Pd6tBOggAe41NnCU5KwqA8JvD6J20/IctszT2E0AvHo=
+github.com/checkly/checkly-go-sdk v1.20.2 h1:SZCmj9Jtxlq760jtZWV5nsA/Q19r075xgVtVuwC3CmA=
+github.com/checkly/checkly-go-sdk v1.20.2/go.mod h1:Pd6tBOggAe41NnCU5KwqA8JvD6J20/IctszT2E0AvHo=
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=


### PR DESCRIPTION
## Affected Components
* [x] Resources
* [x] Test
* [x] Docs
* [ ] Tooling
* [ ] Other

## Pre-Requisites
* [x] Terraform code is formatted with `terraform fmt`
* [x] Go code is formatted with `go fmt`
* [ ] `plan` & `apply` command of `demo/main.tf` file do not produce diffs

## Notes for the Reviewer
This adds top-level `description` support to the legacy `checkly_check` resource, the newer monitor resources (`checkly_url_monitor`, `checkly_tcp_monitor`, `checkly_dns_monitor`, `checkly_icmp_monitor`, `checkly_heartbeat_monitor`), and `checkly_playwright_check_suite`.

The PR also adds acceptance coverage for description set/remove behavior and regenerates the provider docs.

SDK: https://github.com/checkly/checkly-go-sdk/pull/155