### PR TITLE
feat: add WEBHOOK_ROOTLY support to webhook alert channel type

### DIFF
--- a/checkly/helpers.go
+++ b/checkly/helpers.go
@@ -116,4 +116,3 @@ func optionalStringPointerFromResourceData(d *schema.ResourceData, key string) *
 	str := value.(string)
 	return &str
 }
-

--- a/checkly/resource_alert_channel.go
+++ b/checkly/resource_alert_channel.go
@@ -177,11 +177,11 @@ func resourceAlertChannel() *schema.Resource {
 						AcFieldWebhookType: {
 							Type:        schema.TypeString,
 							Optional:    true,
-							Description: "Type of the webhook. Possible values are 'WEBHOOK_DISCORD', 'WEBHOOK_FIREHYDRANT', 'WEBHOOK_GITLAB_ALERT', 'WEBHOOK_SPIKESH', 'WEBHOOK_SPLUNK', 'WEBHOOK_MSTEAMS' and 'WEBHOOK_TELEGRAM'.",
+							Description: "Type of the webhook. Possible values are 'WEBHOOK_DISCORD', 'WEBHOOK_FIREHYDRANT', 'WEBHOOK_GITLAB_ALERT', 'WEBHOOK_ROOTLY', 'WEBHOOK_SPIKESH', 'WEBHOOK_SPLUNK', 'WEBHOOK_MSTEAMS' and 'WEBHOOK_TELEGRAM'. For 'WEBHOOK_ROOTLY', two routing modes are supported: In-App Routing uses url 'https://webhooks.rootly.com/webhooks/incoming/checkly_webhooks' and routes via Rootly Alert Routes; Direct Routing uses url 'https://webhooks.rootly.com/webhooks/incoming/checkly_webhooks/notify/<Type>/<ID>' where Type is one of 'Service', 'Group' (Teams), 'EscalationPolicy', or 'Functionality'.",
 							ValidateFunc: func(value interface{}, key string) (warns []string, errs []error) {
 								v := value.(string)
 								isValid := false
-								options := []string{"WEBHOOK_DISCORD", "WEBHOOK_FIREHYDRANT", "WEBHOOK_GITLAB_ALERT", "WEBHOOK_SPIKESH", "WEBHOOK_SPLUNK", "WEBHOOK_MSTEAMS", "WEBHOOK_TELEGRAM"}
+								options := []string{"WEBHOOK_DISCORD", "WEBHOOK_FIREHYDRANT", "WEBHOOK_GITLAB_ALERT", "WEBHOOK_ROOTLY", "WEBHOOK_SPIKESH", "WEBHOOK_SPLUNK", "WEBHOOK_MSTEAMS", "WEBHOOK_TELEGRAM"}
 								for _, option := range options {
 									if v == option {
 										isValid = true

--- a/checkly/resource_alert_channel_test.go
+++ b/checkly/resource_alert_channel_test.go
@@ -6,7 +6,36 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
+
+func TestWebhookTypeValidation(t *testing.T) {
+	r := resourceAlertChannel()
+	webhookSchema := r.Schema[AcFieldWebhook].Elem.(*schema.Resource).Schema
+	validateFunc := webhookSchema[AcFieldWebhookType].ValidateFunc
+
+	valid := []string{
+		"WEBHOOK_DISCORD",
+		"WEBHOOK_FIREHYDRANT",
+		"WEBHOOK_GITLAB_ALERT",
+		"WEBHOOK_ROOTLY",
+		"WEBHOOK_SPIKESH",
+		"WEBHOOK_SPLUNK",
+		"WEBHOOK_MSTEAMS",
+		"WEBHOOK_TELEGRAM",
+	}
+	for _, v := range valid {
+		_, errs := validateFunc(v, AcFieldWebhookType)
+		if len(errs) > 0 {
+			t.Errorf("expected %q to be valid, got errors: %v", v, errs)
+		}
+	}
+
+	_, errs := validateFunc("WEBHOOK_UNKNOWN", AcFieldWebhookType)
+	if len(errs) == 0 {
+		t.Error("expected 'WEBHOOK_UNKNOWN' to be invalid, but got no errors")
+	}
+}
 
 func TestAccEmail(t *testing.T) {
 	accTestCase(t, []resource.TestStep{

--- a/demo/alert-channels.tf
+++ b/demo/alert-channels.tf
@@ -93,3 +93,57 @@ resource "checkly_alert_channel" "firehydrant_ac" {
     webhook_type = "WEBHOOK_FIREHYDRANT"
   }
 }
+
+# A Rootly alert channel — In-App Routing mode.
+# Alerts are sent to Rootly and routed internally via Rootly Alert Routes.
+resource "checkly_alert_channel" "rootly_inapp_ac" {
+  webhook {
+    name           = "Rootly (In-App Routing)"
+    method         = "POST"
+    url            = "https://webhooks.rootly.com/webhooks/incoming/checkly_webhooks"
+    webhook_secret = "<rootly-webhook-secret>"
+    webhook_type   = "WEBHOOK_ROOTLY"
+    template       = <<EOT
+{
+  "alert_type": "{{ALERT_TYPE}}",
+  "check_id": "{{CHECK_ID}}",
+  "check_result_id": "{{CHECK_RESULT_ID}}",
+  "check_name": "{{CHECK_NAME}}",
+  "alert_title": "{{ALERT_TITLE}}",
+  "started_at": "{{STARTED_AT}}",
+  "link": "{{RESULT_LINK}}"
+}
+EOT
+  }
+
+  send_recovery = true
+  send_failure  = true
+}
+
+# A Rootly alert channel — Direct Routing mode.
+# Alerts are routed directly to a specific Rootly target via the URL.
+# Type is one of: Service, Group (for Teams), EscalationPolicy, Functionality.
+# The target ID can be found in the Rootly UI for the chosen resource.
+resource "checkly_alert_channel" "rootly_direct_ac" {
+  webhook {
+    name           = "Rootly (Direct Routing)"
+    method         = "POST"
+    url            = "https://webhooks.rootly.com/webhooks/incoming/checkly_webhooks/notify/EscalationPolicy/<rootly-escalation-policy-id>"
+    webhook_secret = "<rootly-webhook-secret>"
+    webhook_type   = "WEBHOOK_ROOTLY"
+    template       = <<EOT
+{
+  "alert_type": "{{ALERT_TYPE}}",
+  "check_id": "{{CHECK_ID}}",
+  "check_result_id": "{{CHECK_RESULT_ID}}",
+  "check_name": "{{CHECK_NAME}}",
+  "alert_title": "{{ALERT_TITLE}}",
+  "started_at": "{{STARTED_AT}}",
+  "link": "{{RESULT_LINK}}"
+}
+EOT
+  }
+
+  send_recovery = true
+  send_failure  = true
+}

--- a/docs/resources/alert_channel.md
+++ b/docs/resources/alert_channel.md
@@ -94,6 +94,60 @@ resource "checkly_alert_channel" "firehydrant_ac" {
   }
 }
 
+# A Rootly alert channel — In-App Routing mode.
+# Alerts are sent to Rootly and routed internally via Rootly Alert Routes.
+resource "checkly_alert_channel" "rootly_inapp_ac" {
+  webhook {
+    name           = "Rootly (In-App Routing)"
+    method         = "POST"
+    url            = "https://webhooks.rootly.com/webhooks/incoming/checkly_webhooks"
+    webhook_secret = "<rootly-webhook-secret>"
+    webhook_type   = "WEBHOOK_ROOTLY"
+    template       = <<EOT
+{
+  "alert_type": "{{ALERT_TYPE}}",
+  "check_id": "{{CHECK_ID}}",
+  "check_result_id": "{{CHECK_RESULT_ID}}",
+  "check_name": "{{CHECK_NAME}}",
+  "alert_title": "{{ALERT_TITLE}}",
+  "started_at": "{{STARTED_AT}}",
+  "link": "{{RESULT_LINK}}"
+}
+EOT
+  }
+
+  send_recovery = true
+  send_failure  = true
+}
+
+# A Rootly alert channel — Direct Routing mode.
+# Alerts are routed directly to a specific Rootly target via the URL.
+# Type is one of: Service, Group (for Teams), EscalationPolicy, Functionality.
+# The target ID can be found in the Rootly UI for the chosen resource.
+resource "checkly_alert_channel" "rootly_direct_ac" {
+  webhook {
+    name           = "Rootly (Direct Routing)"
+    method         = "POST"
+    url            = "https://webhooks.rootly.com/webhooks/incoming/checkly_webhooks/notify/EscalationPolicy/<rootly-escalation-policy-id>"
+    webhook_secret = "<rootly-webhook-secret>"
+    webhook_type   = "WEBHOOK_ROOTLY"
+    template       = <<EOT
+{
+  "alert_type": "{{ALERT_TYPE}}",
+  "check_id": "{{CHECK_ID}}",
+  "check_result_id": "{{CHECK_RESULT_ID}}",
+  "check_name": "{{CHECK_NAME}}",
+  "alert_title": "{{ALERT_TITLE}}",
+  "started_at": "{{STARTED_AT}}",
+  "link": "{{RESULT_LINK}}"
+}
+EOT
+  }
+
+  send_recovery = true
+  send_failure  = true
+}
+
 # Connecting the alert channel to a check
 resource "checkly_check" "example_check" {
   name = "Example check"
@@ -206,4 +260,4 @@ Optional:
 - `query_parameters` (Map of String)
 - `template` (String)
 - `webhook_secret` (String)
-- `webhook_type` (String) Type of the webhook. Possible values are 'WEBHOOK_DISCORD', 'WEBHOOK_FIREHYDRANT', 'WEBHOOK_GITLAB_ALERT', 'WEBHOOK_SPIKESH', 'WEBHOOK_SPLUNK', 'WEBHOOK_MSTEAMS' and 'WEBHOOK_TELEGRAM'.
+- `webhook_type` (String) Type of the webhook. Possible values are 'WEBHOOK_DISCORD', 'WEBHOOK_FIREHYDRANT', 'WEBHOOK_GITLAB_ALERT', 'WEBHOOK_ROOTLY', 'WEBHOOK_SPIKESH', 'WEBHOOK_SPLUNK', 'WEBHOOK_MSTEAMS' and 'WEBHOOK_TELEGRAM'. For 'WEBHOOK_ROOTLY', two routing modes are supported: In-App Routing uses url 'https://webhooks.rootly.com/webhooks/incoming/checkly_webhooks' and routes via Rootly Alert Routes; Direct Routing uses url 'https://webhooks.rootly.com/webhooks/incoming/checkly_webhooks/notify/<Type>/<ID>' where Type is one of 'Service', 'Group' (Teams), 'EscalationPolicy', or 'Functionality'.

--- a/examples/resources/checkly_alert_channel/resource.tf
+++ b/examples/resources/checkly_alert_channel/resource.tf
@@ -79,6 +79,60 @@ resource "checkly_alert_channel" "firehydrant_ac" {
   }
 }
 
+# A Rootly alert channel — In-App Routing mode.
+# Alerts are sent to Rootly and routed internally via Rootly Alert Routes.
+resource "checkly_alert_channel" "rootly_inapp_ac" {
+  webhook {
+    name           = "Rootly (In-App Routing)"
+    method         = "POST"
+    url            = "https://webhooks.rootly.com/webhooks/incoming/checkly_webhooks"
+    webhook_secret = "<rootly-webhook-secret>"
+    webhook_type   = "WEBHOOK_ROOTLY"
+    template       = <<EOT
+{
+  "alert_type": "{{ALERT_TYPE}}",
+  "check_id": "{{CHECK_ID}}",
+  "check_result_id": "{{CHECK_RESULT_ID}}",
+  "check_name": "{{CHECK_NAME}}",
+  "alert_title": "{{ALERT_TITLE}}",
+  "started_at": "{{STARTED_AT}}",
+  "link": "{{RESULT_LINK}}"
+}
+EOT
+  }
+
+  send_recovery = true
+  send_failure  = true
+}
+
+# A Rootly alert channel — Direct Routing mode.
+# Alerts are routed directly to a specific Rootly target via the URL.
+# Type is one of: Service, Group (for Teams), EscalationPolicy, Functionality.
+# The target ID can be found in the Rootly UI for the chosen resource.
+resource "checkly_alert_channel" "rootly_direct_ac" {
+  webhook {
+    name           = "Rootly (Direct Routing)"
+    method         = "POST"
+    url            = "https://webhooks.rootly.com/webhooks/incoming/checkly_webhooks/notify/EscalationPolicy/<rootly-escalation-policy-id>"
+    webhook_secret = "<rootly-webhook-secret>"
+    webhook_type   = "WEBHOOK_ROOTLY"
+    template       = <<EOT
+{
+  "alert_type": "{{ALERT_TYPE}}",
+  "check_id": "{{CHECK_ID}}",
+  "check_result_id": "{{CHECK_RESULT_ID}}",
+  "check_name": "{{CHECK_NAME}}",
+  "alert_title": "{{ALERT_TITLE}}",
+  "started_at": "{{STARTED_AT}}",
+  "link": "{{RESULT_LINK}}"
+}
+EOT
+  }
+
+  send_recovery = true
+  send_failure  = true
+}
+
 # Connecting the alert channel to a check
 resource "checkly_check" "example_check" {
   name = "Example check"


### PR DESCRIPTION
## Summary

- Adds `WEBHOOK_ROOTLY` as a valid value for `webhook_type` in the `checkly_alert_channel` webhook block
- Updates the field description to document both Rootly routing modes (In-App and Direct)
- Adds examples and demo showing both routing modes

Closes #368

## Rootly Routing Modes

**In-App Routing** — alerts sent to Rootly and routed internally via Rootly Alert Routes:
```hcl
webhook {
  url          = "https://webhooks.rootly.com/webhooks/incoming/checkly_webhooks"
  webhook_type = "WEBHOOK_ROOTLY"
}
```

**Direct Routing** — alerts routed directly to a specific target via the URL (`Service`, `Group`, `EscalationPolicy`, or `Functionality`):
```hcl
webhook {
  url          = "https://webhooks.rootly.com/webhooks/incoming/checkly_webhooks/notify/EscalationPolicy/<id>"
  webhook_type = "WEBHOOK_ROOTLY"
}
```

## Changes

- `checkly/resource_alert_channel.go` — added `WEBHOOK_ROOTLY` to `ValidateFunc` allowed values and updated description
- `checkly/resource_alert_channel_test.go` — added unit test covering all valid `webhook_type` values including `WEBHOOK_ROOTLY`
- `examples/resources/checkly_alert_channel/resource.tf` — added both routing mode examples
- `demo/alert-channels.tf` — added both routing mode demos
- `docs/resources/alert_channel.md` — regenerated via `make doc`

## Test Plan

- [x] Unit test `TestWebhookTypeValidation` passes — validates all allowed values including `WEBHOOK_ROOTLY` and rejects unknown values
- [x] `make fmt` clean
- [x] `make doc` regenerated

## Notes

No SDK changes required. The existing `AlertChannelWebhook` struct and `WEBHOOK` alert type already handle this — `WEBHOOK_ROOTLY` is just another `webhookType` value. The Checkly API already supports it (verified against a live channel).