### PR TITLE
feat: add missing webhook types (Rootly, Coralogix, iLert, Incident.io)

### DIFF
--- a/checkly/helpers.go
+++ b/checkly/helpers.go
@@ -116,4 +116,3 @@ func optionalStringPointerFromResourceData(d *schema.ResourceData, key string) *
 	str := value.(string)
 	return &str
 }
-

--- a/checkly/resource_alert_channel.go
+++ b/checkly/resource_alert_channel.go
@@ -177,11 +177,11 @@ func resourceAlertChannel() *schema.Resource {
 						AcFieldWebhookType: {
 							Type:        schema.TypeString,
 							Optional:    true,
-							Description: "Type of the webhook. Possible values are 'WEBHOOK_DISCORD', 'WEBHOOK_FIREHYDRANT', 'WEBHOOK_GITLAB_ALERT', 'WEBHOOK_SPIKESH', 'WEBHOOK_SPLUNK', 'WEBHOOK_MSTEAMS' and 'WEBHOOK_TELEGRAM'.",
+							Description: "Type of the webhook. Possible values are 'WEBHOOK_DISCORD', 'WEBHOOK_FIREHYDRANT', 'WEBHOOK_GITLAB_ALERT', 'WEBHOOK_ROOTLY', 'WEBHOOK_SPIKESH', 'WEBHOOK_SPLUNK', 'WEBHOOK_MSTEAMS' and 'WEBHOOK_TELEGRAM'. For 'WEBHOOK_ROOTLY', two routing modes are supported: In-App Routing uses url 'https://webhooks.rootly.com/webhooks/incoming/checkly_webhooks' and routes via Rootly Alert Routes; Direct Routing uses url 'https://webhooks.rootly.com/webhooks/incoming/checkly_webhooks/notify/<Type>/<ID>' where Type is one of 'Service', 'Group' (Teams), 'EscalationPolicy', or 'Functionality'.",
 							ValidateFunc: func(value interface{}, key string) (warns []string, errs []error) {
 								v := value.(string)
 								isValid := false
-								options := []string{"WEBHOOK_DISCORD", "WEBHOOK_FIREHYDRANT", "WEBHOOK_GITLAB_ALERT", "WEBHOOK_SPIKESH", "WEBHOOK_SPLUNK", "WEBHOOK_MSTEAMS", "WEBHOOK_TELEGRAM"}
+								options := []string{"WEBHOOK_DISCORD", "WEBHOOK_FIREHYDRANT", "WEBHOOK_GITLAB_ALERT", "WEBHOOK_ROOTLY", "WEBHOOK_SPIKESH", "WEBHOOK_SPLUNK", "WEBHOOK_MSTEAMS", "WEBHOOK_TELEGRAM"}
 								for _, option := range options {
 									if v == option {
 										isValid = true

--- a/checkly/resource_alert_channel.go
+++ b/checkly/resource_alert_channel.go
@@ -49,13 +49,16 @@ const (
 )
 
 var webhookTypes = allowedValues[string]{
+	{Value: "WEBHOOK_CORALOGIX"},
 	{Value: "WEBHOOK_DISCORD"},
 	{Value: "WEBHOOK_FIREHYDRANT"},
 	{Value: "WEBHOOK_GITLAB_ALERT"},
+	{Value: "WEBHOOK_ILERT"},
+	{Value: "WEBHOOK_INCIDENTIO"},
+	{Value: "WEBHOOK_MSTEAMS"},
 	{Value: "WEBHOOK_ROOTLY"},
 	{Value: "WEBHOOK_SPIKESH"},
 	{Value: "WEBHOOK_SPLUNK"},
-	{Value: "WEBHOOK_MSTEAMS"},
 	{Value: "WEBHOOK_TELEGRAM"},
 }
 

--- a/checkly/resource_alert_channel.go
+++ b/checkly/resource_alert_channel.go
@@ -48,6 +48,17 @@ const (
 	AcFieldCallNumber           = "number"
 )
 
+var webhookTypes = allowedValues[string]{
+	{Value: "WEBHOOK_DISCORD"},
+	{Value: "WEBHOOK_FIREHYDRANT"},
+	{Value: "WEBHOOK_GITLAB_ALERT"},
+	{Value: "WEBHOOK_ROOTLY"},
+	{Value: "WEBHOOK_SPIKESH"},
+	{Value: "WEBHOOK_SPLUNK"},
+	{Value: "WEBHOOK_MSTEAMS"},
+	{Value: "WEBHOOK_TELEGRAM"},
+}
+
 func resourceAlertChannel() *schema.Resource {
 	return &schema.Resource{
 		Description: "Allows you to define alerting channels for the checks and groups in your account",
@@ -175,23 +186,10 @@ func resourceAlertChannel() *schema.Resource {
 							Optional: true,
 						},
 						AcFieldWebhookType: {
-							Type:        schema.TypeString,
-							Optional:    true,
-							Description: "Type of the webhook. Possible values are 'WEBHOOK_DISCORD', 'WEBHOOK_FIREHYDRANT', 'WEBHOOK_GITLAB_ALERT', 'WEBHOOK_ROOTLY', 'WEBHOOK_SPIKESH', 'WEBHOOK_SPLUNK', 'WEBHOOK_MSTEAMS' and 'WEBHOOK_TELEGRAM'. For 'WEBHOOK_ROOTLY', two routing modes are supported: In-App Routing uses url 'https://webhooks.rootly.com/webhooks/incoming/checkly_webhooks' and routes via Rootly Alert Routes; Direct Routing uses url 'https://webhooks.rootly.com/webhooks/incoming/checkly_webhooks/notify/<Type>/<ID>' where Type is one of 'Service', 'Group' (Teams), 'EscalationPolicy', or 'Functionality'.",
-							ValidateFunc: func(value interface{}, key string) (warns []string, errs []error) {
-								v := value.(string)
-								isValid := false
-								options := []string{"WEBHOOK_DISCORD", "WEBHOOK_FIREHYDRANT", "WEBHOOK_GITLAB_ALERT", "WEBHOOK_ROOTLY", "WEBHOOK_SPIKESH", "WEBHOOK_SPLUNK", "WEBHOOK_MSTEAMS", "WEBHOOK_TELEGRAM"}
-								for _, option := range options {
-									if v == option {
-										isValid = true
-									}
-								}
-								if !isValid {
-									errs = append(errs, fmt.Errorf("%q must be one of %v, got %s", key, options, v))
-								}
-								return warns, errs
-							},
+							Description:  "Type of the webhook. " + webhookTypes.String(),
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validateOneOf(webhookTypes.Values()),
 						},
 					},
 				},

--- a/checkly/resource_alert_channel_test.go
+++ b/checkly/resource_alert_channel_test.go
@@ -6,7 +6,36 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
+
+func TestWebhookTypeValidation(t *testing.T) {
+	r := resourceAlertChannel()
+	webhookSchema := r.Schema[AcFieldWebhook].Elem.(*schema.Resource).Schema
+	validateFunc := webhookSchema[AcFieldWebhookType].ValidateFunc
+
+	valid := []string{
+		"WEBHOOK_DISCORD",
+		"WEBHOOK_FIREHYDRANT",
+		"WEBHOOK_GITLAB_ALERT",
+		"WEBHOOK_ROOTLY",
+		"WEBHOOK_SPIKESH",
+		"WEBHOOK_SPLUNK",
+		"WEBHOOK_MSTEAMS",
+		"WEBHOOK_TELEGRAM",
+	}
+	for _, v := range valid {
+		_, errs := validateFunc(v, AcFieldWebhookType)
+		if len(errs) > 0 {
+			t.Errorf("expected %q to be valid, got errors: %v", v, errs)
+		}
+	}
+
+	_, errs := validateFunc("WEBHOOK_UNKNOWN", AcFieldWebhookType)
+	if len(errs) == 0 {
+		t.Error("expected 'WEBHOOK_UNKNOWN' to be invalid, but got no errors")
+	}
+}
 
 func TestAccEmail(t *testing.T) {
 	accTestCase(t, []resource.TestStep{

--- a/demo/alert-channels.tf
+++ b/demo/alert-channels.tf
@@ -93,3 +93,57 @@ resource "checkly_alert_channel" "firehydrant_ac" {
     webhook_type = "WEBHOOK_FIREHYDRANT"
   }
 }
+
+# A Rootly alert channel — In-App Routing mode.
+# Alerts are sent to Rootly and routed internally via Rootly Alert Routes.
+resource "checkly_alert_channel" "rootly_inapp_ac" {
+  webhook {
+    name           = "Rootly (In-App Routing)"
+    method         = "POST"
+    url            = "https://webhooks.rootly.com/webhooks/incoming/checkly_webhooks"
+    webhook_secret = "<rootly-webhook-secret>"
+    webhook_type   = "WEBHOOK_ROOTLY"
+    template       = <<EOT
+{
+  "alert_type": "{{ALERT_TYPE}}",
+  "check_id": "{{CHECK_ID}}",
+  "check_result_id": "{{CHECK_RESULT_ID}}",
+  "check_name": "{{CHECK_NAME}}",
+  "alert_title": "{{ALERT_TITLE}}",
+  "started_at": "{{STARTED_AT}}",
+  "link": "{{RESULT_LINK}}"
+}
+EOT
+  }
+
+  send_recovery = true
+  send_failure  = true
+}
+
+# A Rootly alert channel — Direct Routing mode.
+# Alerts are routed directly to a specific Rootly target via the URL.
+# Type is one of: Service, Group (for Teams), EscalationPolicy, Functionality.
+# The target ID can be found in the Rootly UI for the chosen resource.
+resource "checkly_alert_channel" "rootly_direct_ac" {
+  webhook {
+    name           = "Rootly (Direct Routing)"
+    method         = "POST"
+    url            = "https://webhooks.rootly.com/webhooks/incoming/checkly_webhooks/notify/EscalationPolicy/<rootly-escalation-policy-id>"
+    webhook_secret = "<rootly-webhook-secret>"
+    webhook_type   = "WEBHOOK_ROOTLY"
+    template       = <<EOT
+{
+  "alert_type": "{{ALERT_TYPE}}",
+  "check_id": "{{CHECK_ID}}",
+  "check_result_id": "{{CHECK_RESULT_ID}}",
+  "check_name": "{{CHECK_NAME}}",
+  "alert_title": "{{ALERT_TITLE}}",
+  "started_at": "{{STARTED_AT}}",
+  "link": "{{RESULT_LINK}}"
+}
+EOT
+  }
+
+  send_recovery = true
+  send_failure  = true
+}

--- a/docs/resources/alert_channel.md
+++ b/docs/resources/alert_channel.md
@@ -94,6 +94,60 @@ resource "checkly_alert_channel" "firehydrant_ac" {
   }
 }
 
+# A Rootly alert channel — In-App Routing mode.
+# Alerts are sent to Rootly and routed internally via Rootly Alert Routes.
+resource "checkly_alert_channel" "rootly_inapp_ac" {
+  webhook {
+    name           = "Rootly (In-App Routing)"
+    method         = "POST"
+    url            = "https://webhooks.rootly.com/webhooks/incoming/checkly_webhooks"
+    webhook_secret = "<rootly-webhook-secret>"
+    webhook_type   = "WEBHOOK_ROOTLY"
+    template       = <<EOT
+{
+  "alert_type": "{{ALERT_TYPE}}",
+  "check_id": "{{CHECK_ID}}",
+  "check_result_id": "{{CHECK_RESULT_ID}}",
+  "check_name": "{{CHECK_NAME}}",
+  "alert_title": "{{ALERT_TITLE}}",
+  "started_at": "{{STARTED_AT}}",
+  "link": "{{RESULT_LINK}}"
+}
+EOT
+  }
+
+  send_recovery = true
+  send_failure  = true
+}
+
+# A Rootly alert channel — Direct Routing mode.
+# Alerts are routed directly to a specific Rootly target via the URL.
+# Type is one of: Service, Group (for Teams), EscalationPolicy, Functionality.
+# The target ID can be found in the Rootly UI for the chosen resource.
+resource "checkly_alert_channel" "rootly_direct_ac" {
+  webhook {
+    name           = "Rootly (Direct Routing)"
+    method         = "POST"
+    url            = "https://webhooks.rootly.com/webhooks/incoming/checkly_webhooks/notify/EscalationPolicy/<rootly-escalation-policy-id>"
+    webhook_secret = "<rootly-webhook-secret>"
+    webhook_type   = "WEBHOOK_ROOTLY"
+    template       = <<EOT
+{
+  "alert_type": "{{ALERT_TYPE}}",
+  "check_id": "{{CHECK_ID}}",
+  "check_result_id": "{{CHECK_RESULT_ID}}",
+  "check_name": "{{CHECK_NAME}}",
+  "alert_title": "{{ALERT_TITLE}}",
+  "started_at": "{{STARTED_AT}}",
+  "link": "{{RESULT_LINK}}"
+}
+EOT
+  }
+
+  send_recovery = true
+  send_failure  = true
+}
+
 # Connecting the alert channel to a check
 resource "checkly_check" "example_check" {
   name = "Example check"
@@ -206,4 +260,4 @@ Optional:
 - `query_parameters` (Map of String)
 - `template` (String)
 - `webhook_secret` (String)
-- `webhook_type` (String) Type of the webhook. Possible values are 'WEBHOOK_DISCORD', 'WEBHOOK_FIREHYDRANT', 'WEBHOOK_GITLAB_ALERT', 'WEBHOOK_SPIKESH', 'WEBHOOK_SPLUNK', 'WEBHOOK_MSTEAMS' and 'WEBHOOK_TELEGRAM'.
+- `webhook_type` (String) Type of the webhook. Possible values are 'WEBHOOK_DISCORD', 'WEBHOOK_FIREHYDRANT', 'WEBHOOK_GITLAB_ALERT', 'WEBHOOK_ROOTLY', 'WEBHOOK_SPIKESH', 'WEBHOOK_SPLUNK', 'WEBHOOK_MSTEAMS' and 'WEBHOOK_TELEGRAM'. For 'WEBHOOK_ROOTLY', two routing modes are supported: In-App Routing uses url 'https://webhooks.rootly.com/webhooks/incoming/checkly_webhooks' and routes via Rootly Alert Routes; Direct Routing uses url 'https://webhooks.rootly.com/webhooks/incoming/checkly_webhooks/notify/<Type>/<ID>' where Type is one of 'Service', 'Group' (Teams), 'EscalationPolicy', or 'Functionality'.

--- a/docs/resources/alert_channel.md
+++ b/docs/resources/alert_channel.md
@@ -260,4 +260,4 @@ Optional:
 - `query_parameters` (Map of String)
 - `template` (String)
 - `webhook_secret` (String)
-- `webhook_type` (String) Type of the webhook. Possible values are 'WEBHOOK_DISCORD', 'WEBHOOK_FIREHYDRANT', 'WEBHOOK_GITLAB_ALERT', 'WEBHOOK_ROOTLY', 'WEBHOOK_SPIKESH', 'WEBHOOK_SPLUNK', 'WEBHOOK_MSTEAMS' and 'WEBHOOK_TELEGRAM'. For 'WEBHOOK_ROOTLY', two routing modes are supported: In-App Routing uses url 'https://webhooks.rootly.com/webhooks/incoming/checkly_webhooks' and routes via Rootly Alert Routes; Direct Routing uses url 'https://webhooks.rootly.com/webhooks/incoming/checkly_webhooks/notify/<Type>/<ID>' where Type is one of 'Service', 'Group' (Teams), 'EscalationPolicy', or 'Functionality'.
+- `webhook_type` (String) Type of the webhook. The allowed values are `WEBHOOK_DISCORD`, `WEBHOOK_FIREHYDRANT`, `WEBHOOK_GITLAB_ALERT`, `WEBHOOK_ROOTLY`, `WEBHOOK_SPIKESH`, `WEBHOOK_SPLUNK`, `WEBHOOK_MSTEAMS` and `WEBHOOK_TELEGRAM`.

--- a/docs/resources/alert_channel.md
+++ b/docs/resources/alert_channel.md
@@ -260,4 +260,4 @@ Optional:
 - `query_parameters` (Map of String)
 - `template` (String)
 - `webhook_secret` (String)
-- `webhook_type` (String) Type of the webhook. The allowed values are `WEBHOOK_DISCORD`, `WEBHOOK_FIREHYDRANT`, `WEBHOOK_GITLAB_ALERT`, `WEBHOOK_ROOTLY`, `WEBHOOK_SPIKESH`, `WEBHOOK_SPLUNK`, `WEBHOOK_MSTEAMS` and `WEBHOOK_TELEGRAM`.
+- `webhook_type` (String) Type of the webhook. The allowed values are `WEBHOOK_CORALOGIX`, `WEBHOOK_DISCORD`, `WEBHOOK_FIREHYDRANT`, `WEBHOOK_GITLAB_ALERT`, `WEBHOOK_ILERT`, `WEBHOOK_INCIDENTIO`, `WEBHOOK_MSTEAMS`, `WEBHOOK_ROOTLY`, `WEBHOOK_SPIKESH`, `WEBHOOK_SPLUNK` and `WEBHOOK_TELEGRAM`.

--- a/examples/resources/checkly_alert_channel/resource.tf
+++ b/examples/resources/checkly_alert_channel/resource.tf
@@ -79,6 +79,60 @@ resource "checkly_alert_channel" "firehydrant_ac" {
   }
 }
 
+# A Rootly alert channel — In-App Routing mode.
+# Alerts are sent to Rootly and routed internally via Rootly Alert Routes.
+resource "checkly_alert_channel" "rootly_inapp_ac" {
+  webhook {
+    name           = "Rootly (In-App Routing)"
+    method         = "POST"
+    url            = "https://webhooks.rootly.com/webhooks/incoming/checkly_webhooks"
+    webhook_secret = "<rootly-webhook-secret>"
+    webhook_type   = "WEBHOOK_ROOTLY"
+    template       = <<EOT
+{
+  "alert_type": "{{ALERT_TYPE}}",
+  "check_id": "{{CHECK_ID}}",
+  "check_result_id": "{{CHECK_RESULT_ID}}",
+  "check_name": "{{CHECK_NAME}}",
+  "alert_title": "{{ALERT_TITLE}}",
+  "started_at": "{{STARTED_AT}}",
+  "link": "{{RESULT_LINK}}"
+}
+EOT
+  }
+
+  send_recovery = true
+  send_failure  = true
+}
+
+# A Rootly alert channel — Direct Routing mode.
+# Alerts are routed directly to a specific Rootly target via the URL.
+# Type is one of: Service, Group (for Teams), EscalationPolicy, Functionality.
+# The target ID can be found in the Rootly UI for the chosen resource.
+resource "checkly_alert_channel" "rootly_direct_ac" {
+  webhook {
+    name           = "Rootly (Direct Routing)"
+    method         = "POST"
+    url            = "https://webhooks.rootly.com/webhooks/incoming/checkly_webhooks/notify/EscalationPolicy/<rootly-escalation-policy-id>"
+    webhook_secret = "<rootly-webhook-secret>"
+    webhook_type   = "WEBHOOK_ROOTLY"
+    template       = <<EOT
+{
+  "alert_type": "{{ALERT_TYPE}}",
+  "check_id": "{{CHECK_ID}}",
+  "check_result_id": "{{CHECK_RESULT_ID}}",
+  "check_name": "{{CHECK_NAME}}",
+  "alert_title": "{{ALERT_TITLE}}",
+  "started_at": "{{STARTED_AT}}",
+  "link": "{{RESULT_LINK}}"
+}
+EOT
+  }
+
+  send_recovery = true
+  send_failure  = true
+}
+
 # Connecting the alert channel to a check
 resource "checkly_check" "example_check" {
   name = "Example check"


### PR DESCRIPTION
## Summary

Based on #369 by @antzangell — adds `WEBHOOK_ROOTLY` support for the alert channel webhook type.

On top of that:
- Refactored `webhook_type` validation to use `allowedValues` helper and `validateOneOf`, replacing the inline `ValidateFunc`
- Moved Rootly-specific routing documentation from the `webhook_type` description to the existing examples
- Added three more missing webhook types: `WEBHOOK_CORALOGIX`, `WEBHOOK_ILERT`, `WEBHOOK_INCIDENTIO`

Closes #368

## Test plan

- [x] Acceptance tests pass for alert channel resources
- [x] `go build` clean
- [x] `make generate` regenerated docs