### PR TITLE
Allow PWCS runtime engine to be selected [RED-515]

### DIFF
--- a/checkly/engine.go
+++ b/checkly/engine.go
@@ -8,7 +8,7 @@ import (
 	"github.com/Masterminds/semver/v3"
 )
 
-var availableNodeVersions = []string{"22", "24"}
+var availableNodeVersions = []string{"22", "24", "26"}
 var availableBunVersions = []string{"1.3"}
 
 type EngineInfo struct {

--- a/checkly/engine.go
+++ b/checkly/engine.go
@@ -3,13 +3,11 @@ package checkly
 import (
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
 )
-
-var availableNodeVersions = []string{"22", "24", "26"}
-var availableBunVersions = []string{"1.3"}
 
 type EngineInfo struct {
 	Name    string
@@ -20,6 +18,7 @@ type EngineDetectionResult struct {
 	Engine     *EngineInfo
 	RawVersion string
 	Source     string
+	Notices    []string
 }
 
 func parseNodeVersionFile(content []byte) string {
@@ -111,43 +110,91 @@ func resolveBunVersion(raw string) string {
 	return fmt.Sprintf("%s.%s", parts[0], parts[1])
 }
 
-func matchAvailableVersion(parsed string, available []string) string {
-	for _, v := range available {
-		if v == parsed {
-			return v
-		}
-	}
-	return ""
+var firstVersionRegex = regexp.MustCompile(`\d+(\.\d+)*`)
+
+// extractVersionFromConstraint extracts the first version-like string from a
+// semver constraint (e.g., ">=22" → "22", "^1.3" → "1.3").
+func extractVersionFromConstraint(constraint string) string {
+	m := firstVersionRegex.FindString(constraint)
+	return m
 }
 
-func matchSemverConstraint(constraint string, available []string) string {
-	c, err := semver.NewConstraint(constraint)
-	if err != nil {
-		return ""
+// resolveVersionForEngine resolves a raw version string using the engine rules.
+// Returns the resolved version (or empty if denied/unparseable) and any notices.
+func resolveVersionForEngine(engineName string, rawVersion string) (string, []string) {
+	config, ok := engineConfigs[engineName]
+	if !ok {
+		return rawVersion, nil
 	}
 
-	var best string
-	var bestVer *semver.Version
-	for _, v := range available {
-		padded := v
-		switch strings.Count(padded, ".") {
-		case 0:
-			padded += ".0.0"
-		case 1:
-			padded += ".0"
-		}
-		sv, err := semver.NewVersion(padded)
-		if err != nil {
-			continue
-		}
-		if c.Check(sv) {
-			if bestVer == nil || sv.GreaterThan(bestVer) {
-				best = v
-				bestVer = sv
+	var version string
+	if engineName == "node" {
+		version = resolveNodeMajorVersion(rawVersion)
+	} else {
+		version = resolveBunVersion(rawVersion)
+	}
+	if version == "" {
+		return "", nil
+	}
+
+	res := resolveEngineVersion(version, config)
+	if res.Denied {
+		return "", res.Notices
+	}
+	return res.Version, res.Notices
+}
+
+// resolveConstraintForEngine resolves a semver constraint (from package.json engines)
+// through the engine rules. Extracts the base version, then applies rules.
+func resolveConstraintForEngine(engineName string, constraint string) (string, []string) {
+	// Try semver.minVersion first for accurate resolution
+	c, err := semver.NewConstraint(constraint)
+	if err == nil {
+		// Test versions from the rules' targets to find the best match
+		config := engineConfigs[engineName]
+		var best string
+		var bestVer *semver.Version
+		targets := collectTargets(config)
+		for _, t := range targets {
+			sv, err := semver.NewVersion(t)
+			if err != nil {
+				continue
+			}
+			if c.Check(sv) {
+				if bestVer == nil || sv.GreaterThan(bestVer) {
+					best = t
+					bestVer = sv
+				}
 			}
 		}
+		if best != "" {
+			return resolveVersionForEngine(engineName, best)
+		}
 	}
-	return best
+
+	// Fallback: extract first version-like string from constraint
+	extracted := extractVersionFromConstraint(constraint)
+	if extracted == "" {
+		return "", nil
+	}
+	return resolveVersionForEngine(engineName, extracted)
+}
+
+// collectTargets returns all unique target versions from the rules (plus default).
+func collectTargets(config engineVersionConfig) []string {
+	seen := make(map[string]bool)
+	var targets []string
+	if config.Default != "" {
+		seen[config.Default] = true
+		targets = append(targets, config.Default)
+	}
+	for _, r := range config.Rules {
+		if r.Target != "" && !seen[r.Target] {
+			seen[r.Target] = true
+			targets = append(targets, r.Target)
+		}
+	}
+	return targets
 }
 
 func detectEngine(files map[string][]byte, packageManager string) *EngineDetectionResult {
@@ -158,27 +205,25 @@ func detectEngine(files map[string][]byte, packageManager string) *EngineDetecti
 		version    string
 		rawVersion string
 		source     string
+		notices    []string
 	}
 
 	var nodeCandidate, bunCandidate *candidate
 
-	// Helper: try to match a raw version to available node versions, record candidate either way.
 	tryNode := func(raw, source string) {
 		if nodeCandidate != nil {
 			return
 		}
-		major := resolveNodeMajorVersion(raw)
-		matched := matchAvailableVersion(major, availableNodeVersions)
-		nodeCandidate = &candidate{engine: "node", version: matched, rawVersion: raw, source: source}
+		resolved, notices := resolveVersionForEngine("node", raw)
+		nodeCandidate = &candidate{engine: "node", version: resolved, rawVersion: raw, source: source, notices: notices}
 	}
 
 	tryBun := func(raw, source string) {
 		if bunCandidate != nil {
 			return
 		}
-		minor := resolveBunVersion(raw)
-		matched := matchAvailableVersion(minor, availableBunVersions)
-		bunCandidate = &candidate{engine: "bun", version: matched, rawVersion: raw, source: source}
+		resolved, notices := resolveVersionForEngine("bun", raw)
+		bunCandidate = &candidate{engine: "bun", version: resolved, rawVersion: raw, source: source, notices: notices}
 	}
 
 	// 1. .node-version (pinning file)
@@ -221,23 +266,23 @@ func detectEngine(files map[string][]byte, packageManager string) *EngineDetecti
 	if raw, ok := files["package.json"]; ok {
 		nodeRange, bunRange := parsePackageJSONEngines(raw)
 		if nodeCandidate == nil && nodeRange != "" {
-			if matched := matchSemverConstraint(nodeRange, availableNodeVersions); matched != "" {
-				nodeCandidate = &candidate{engine: "node", version: matched, rawVersion: nodeRange, source: "package.json engines.node"}
+			if resolved, notices := resolveConstraintForEngine("node", nodeRange); resolved != "" {
+				nodeCandidate = &candidate{engine: "node", version: resolved, rawVersion: nodeRange, source: "package.json engines.node", notices: notices}
 			}
 		}
 		if bunCandidate == nil && bunRange != "" {
-			if matched := matchSemverConstraint(bunRange, availableBunVersions); matched != "" {
-				bunCandidate = &candidate{engine: "bun", version: matched, rawVersion: bunRange, source: "package.json engines.bun"}
+			if resolved, notices := resolveConstraintForEngine("bun", bunRange); resolved != "" {
+				bunCandidate = &candidate{engine: "bun", version: resolved, rawVersion: bunRange, source: "package.json engines.bun", notices: notices}
 			}
 		}
 	}
 
-	// Select based on package manager tiebreaker
 	toResult := func(c *candidate) *EngineDetectionResult {
 		return &EngineDetectionResult{
 			Engine:     &EngineInfo{Name: c.engine, Version: c.version},
 			RawVersion: c.rawVersion,
 			Source:     c.source,
+			Notices:    c.notices,
 		}
 	}
 
@@ -257,6 +302,5 @@ func detectEngine(files map[string][]byte, packageManager string) *EngineDetecti
 		}
 	}
 
-	// No version files found — return nil to let the runner choose.
 	return nil
 }

--- a/checkly/engine.go
+++ b/checkly/engine.go
@@ -257,9 +257,6 @@ func detectEngine(files map[string][]byte, packageManager string) *EngineDetecti
 		}
 	}
 
-	// 6. Fallback: infer from package manager (no version files found at all)
-	if preferBun {
-		return &EngineDetectionResult{Engine: &EngineInfo{Name: "bun", Version: "1.3"}}
-	}
-	return &EngineDetectionResult{Engine: &EngineInfo{Name: "node", Version: "22"}}
+	// No version files found — return nil to let the runner choose.
+	return nil
 }

--- a/checkly/engine.go
+++ b/checkly/engine.go
@@ -16,6 +16,12 @@ type EngineInfo struct {
 	Version string
 }
 
+type EngineDetectionResult struct {
+	Engine     *EngineInfo
+	RawVersion string
+	Source     string
+}
+
 func parseNodeVersionFile(content []byte) string {
 	s := strings.TrimSpace(string(content))
 	s = strings.TrimPrefix(s, "v")
@@ -123,7 +129,6 @@ func matchSemverConstraint(constraint string, available []string) string {
 	var best string
 	var bestVer *semver.Version
 	for _, v := range available {
-		// Pad to valid semver: "22" → "22.0.0", "1.3" → "1.3.0"
 		padded := v
 		switch strings.Count(padded, ".") {
 		case 0:
@@ -145,102 +150,116 @@ func matchSemverConstraint(constraint string, available []string) string {
 	return best
 }
 
-func detectEngine(files map[string][]byte, packageManager string) *EngineInfo {
+func detectEngine(files map[string][]byte, packageManager string) *EngineDetectionResult {
 	preferBun := packageManager == "bun"
 
 	type candidate struct {
-		engine  string
-		version string
+		engine     string
+		version    string
+		rawVersion string
+		source     string
 	}
 
 	var nodeCandidate, bunCandidate *candidate
 
-	// 1. .node-version
+	// Helper: try to match a raw version to available node versions, record candidate either way.
+	tryNode := func(raw, source string) {
+		if nodeCandidate != nil {
+			return
+		}
+		major := resolveNodeMajorVersion(raw)
+		matched := matchAvailableVersion(major, availableNodeVersions)
+		nodeCandidate = &candidate{engine: "node", version: matched, rawVersion: raw, source: source}
+	}
+
+	tryBun := func(raw, source string) {
+		if bunCandidate != nil {
+			return
+		}
+		minor := resolveBunVersion(raw)
+		matched := matchAvailableVersion(minor, availableBunVersions)
+		bunCandidate = &candidate{engine: "bun", version: matched, rawVersion: raw, source: source}
+	}
+
+	// 1. .node-version (pinning file)
 	if raw, ok := files[".node-version"]; ok {
 		if parsed := parseNodeVersionFile(raw); parsed != "" {
-			major := resolveNodeMajorVersion(parsed)
-			if matched := matchAvailableVersion(major, availableNodeVersions); matched != "" {
-				nodeCandidate = &candidate{engine: "node", version: matched}
-			}
+			tryNode(parsed, ".node-version")
 		}
 	}
 
-	// 2. .nvmrc (only if no .node-version match yet)
+	// 2. .nvmrc (pinning file, only if no .node-version found)
 	if nodeCandidate == nil {
 		if raw, ok := files[".nvmrc"]; ok {
 			if parsed := parseNvmrcFile(raw); parsed != "" {
-				major := resolveNodeMajorVersion(parsed)
-				if matched := matchAvailableVersion(major, availableNodeVersions); matched != "" {
-					nodeCandidate = &candidate{engine: "node", version: matched}
-				}
+				tryNode(parsed, ".nvmrc")
 			}
 		}
 	}
 
-	// 3. .tool-versions
+	// 3. .tool-versions (pinning file)
 	if raw, ok := files[".tool-versions"]; ok {
 		tvNodeVersion, tvBunVersion := parseToolVersionsFile(raw)
 		if tvNodeVersion != "" && nodeCandidate == nil {
-			major := resolveNodeMajorVersion(tvNodeVersion)
-			if matched := matchAvailableVersion(major, availableNodeVersions); matched != "" {
-				nodeCandidate = &candidate{engine: "node", version: matched}
-			}
+			tryNode(tvNodeVersion, ".tool-versions")
 		}
 		if tvBunVersion != "" && bunCandidate == nil {
-			minor := resolveBunVersion(tvBunVersion)
-			if matched := matchAvailableVersion(minor, availableBunVersions); matched != "" {
-				bunCandidate = &candidate{engine: "bun", version: matched}
-			}
+			tryBun(tvBunVersion, ".tool-versions")
 		}
 	}
 
-	// 4. .bun-version
+	// 4. .bun-version (pinning file)
 	if bunCandidate == nil {
 		if raw, ok := files[".bun-version"]; ok {
 			if parsed := parseBunVersionFile(raw); parsed != "" {
-				minor := resolveBunVersion(parsed)
-				if matched := matchAvailableVersion(minor, availableBunVersions); matched != "" {
-					bunCandidate = &candidate{engine: "bun", version: matched}
-				}
+				tryBun(parsed, ".bun-version")
 			}
 		}
 	}
 
-	// 5. package.json engines
+	// 5. package.json engines (range file — only consulted when no pinning file was found for that engine)
 	if raw, ok := files["package.json"]; ok {
 		nodeRange, bunRange := parsePackageJSONEngines(raw)
 		if nodeCandidate == nil && nodeRange != "" {
 			if matched := matchSemverConstraint(nodeRange, availableNodeVersions); matched != "" {
-				nodeCandidate = &candidate{engine: "node", version: matched}
+				nodeCandidate = &candidate{engine: "node", version: matched, rawVersion: nodeRange, source: "package.json engines.node"}
 			}
 		}
 		if bunCandidate == nil && bunRange != "" {
 			if matched := matchSemverConstraint(bunRange, availableBunVersions); matched != "" {
-				bunCandidate = &candidate{engine: "bun", version: matched}
+				bunCandidate = &candidate{engine: "bun", version: matched, rawVersion: bunRange, source: "package.json engines.bun"}
 			}
 		}
 	}
 
 	// Select based on package manager tiebreaker
-	if preferBun {
-		if bunCandidate != nil {
-			return &EngineInfo{Name: bunCandidate.engine, Version: bunCandidate.version}
-		}
-		if nodeCandidate != nil {
-			return &EngineInfo{Name: nodeCandidate.engine, Version: nodeCandidate.version}
-		}
-	} else {
-		if nodeCandidate != nil {
-			return &EngineInfo{Name: nodeCandidate.engine, Version: nodeCandidate.version}
-		}
-		if bunCandidate != nil {
-			return &EngineInfo{Name: bunCandidate.engine, Version: bunCandidate.version}
+	toResult := func(c *candidate) *EngineDetectionResult {
+		return &EngineDetectionResult{
+			Engine:     &EngineInfo{Name: c.engine, Version: c.version},
+			RawVersion: c.rawVersion,
+			Source:     c.source,
 		}
 	}
 
-	// 6. Fallback: infer from package manager
 	if preferBun {
-		return &EngineInfo{Name: "bun", Version: "1.3"}
+		if bunCandidate != nil {
+			return toResult(bunCandidate)
+		}
+		if nodeCandidate != nil {
+			return toResult(nodeCandidate)
+		}
+	} else {
+		if nodeCandidate != nil {
+			return toResult(nodeCandidate)
+		}
+		if bunCandidate != nil {
+			return toResult(bunCandidate)
+		}
 	}
-	return &EngineInfo{Name: "node", Version: "22"}
+
+	// 6. Fallback: infer from package manager (no version files found at all)
+	if preferBun {
+		return &EngineDetectionResult{Engine: &EngineInfo{Name: "bun", Version: "1.3"}}
+	}
+	return &EngineDetectionResult{Engine: &EngineInfo{Name: "node", Version: "22"}}
 }

--- a/checkly/engine.go
+++ b/checkly/engine.go
@@ -1,0 +1,246 @@
+package checkly
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+)
+
+var availableNodeVersions = []string{"22", "24"}
+var availableBunVersions = []string{"1.3"}
+
+type EngineInfo struct {
+	Name    string
+	Version string
+}
+
+func parseNodeVersionFile(content []byte) string {
+	s := strings.TrimSpace(string(content))
+	s = strings.TrimPrefix(s, "v")
+	return s
+}
+
+func parseNvmrcFile(content []byte) string {
+	s := strings.TrimSpace(string(content))
+	if s == "" {
+		return ""
+	}
+	if strings.HasPrefix(s, "lts/") || s == "lts" || s == "node" || s == "stable" || s == "latest" {
+		return ""
+	}
+	s = strings.TrimPrefix(s, "v")
+	return s
+}
+
+func parseToolVersionsFile(content []byte) (nodeVersion string, bunVersion string) {
+	for _, line := range strings.Split(string(content), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		parts := strings.Fields(line)
+		if len(parts) < 2 {
+			continue
+		}
+		switch parts[0] {
+		case "nodejs":
+			if nodeVersion == "" {
+				nodeVersion = strings.TrimPrefix(parts[1], "v")
+			}
+		case "bun":
+			if bunVersion == "" {
+				bunVersion = strings.TrimPrefix(parts[1], "v")
+			}
+		}
+	}
+	return nodeVersion, bunVersion
+}
+
+func parseBunVersionFile(content []byte) string {
+	s := strings.TrimSpace(string(content))
+	s = strings.TrimPrefix(s, "v")
+	return s
+}
+
+func parsePackageJSONEngines(content []byte) (nodeRange string, bunRange string) {
+	var pkg struct {
+		Engines struct {
+			Node string `json:"node"`
+			Bun  string `json:"bun"`
+		} `json:"engines"`
+	}
+	if err := json.Unmarshal(content, &pkg); err != nil {
+		return "", ""
+	}
+	return pkg.Engines.Node, pkg.Engines.Bun
+}
+
+func resolveNodeMajorVersion(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	parts := strings.SplitN(raw, ".", 2)
+	major := parts[0]
+	if major == "" {
+		return ""
+	}
+	for _, c := range major {
+		if c < '0' || c > '9' {
+			return ""
+		}
+	}
+	return major
+}
+
+func resolveBunVersion(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	parts := strings.SplitN(raw, ".", 3)
+	if len(parts) < 2 {
+		return parts[0]
+	}
+	return fmt.Sprintf("%s.%s", parts[0], parts[1])
+}
+
+func matchAvailableVersion(parsed string, available []string) string {
+	for _, v := range available {
+		if v == parsed {
+			return v
+		}
+	}
+	return ""
+}
+
+func matchSemverConstraint(constraint string, available []string) string {
+	c, err := semver.NewConstraint(constraint)
+	if err != nil {
+		return ""
+	}
+
+	var best string
+	var bestVer *semver.Version
+	for _, v := range available {
+		// Pad to valid semver: "22" → "22.0.0", "1.3" → "1.3.0"
+		padded := v
+		switch strings.Count(padded, ".") {
+		case 0:
+			padded += ".0.0"
+		case 1:
+			padded += ".0"
+		}
+		sv, err := semver.NewVersion(padded)
+		if err != nil {
+			continue
+		}
+		if c.Check(sv) {
+			if bestVer == nil || sv.GreaterThan(bestVer) {
+				best = v
+				bestVer = sv
+			}
+		}
+	}
+	return best
+}
+
+func detectEngine(files map[string][]byte, packageManager string) *EngineInfo {
+	preferBun := packageManager == "bun"
+
+	type candidate struct {
+		engine  string
+		version string
+	}
+
+	var nodeCandidate, bunCandidate *candidate
+
+	// 1. .node-version
+	if raw, ok := files[".node-version"]; ok {
+		if parsed := parseNodeVersionFile(raw); parsed != "" {
+			major := resolveNodeMajorVersion(parsed)
+			if matched := matchAvailableVersion(major, availableNodeVersions); matched != "" {
+				nodeCandidate = &candidate{engine: "node", version: matched}
+			}
+		}
+	}
+
+	// 2. .nvmrc (only if no .node-version match yet)
+	if nodeCandidate == nil {
+		if raw, ok := files[".nvmrc"]; ok {
+			if parsed := parseNvmrcFile(raw); parsed != "" {
+				major := resolveNodeMajorVersion(parsed)
+				if matched := matchAvailableVersion(major, availableNodeVersions); matched != "" {
+					nodeCandidate = &candidate{engine: "node", version: matched}
+				}
+			}
+		}
+	}
+
+	// 3. .tool-versions
+	if raw, ok := files[".tool-versions"]; ok {
+		tvNodeVersion, tvBunVersion := parseToolVersionsFile(raw)
+		if tvNodeVersion != "" && nodeCandidate == nil {
+			major := resolveNodeMajorVersion(tvNodeVersion)
+			if matched := matchAvailableVersion(major, availableNodeVersions); matched != "" {
+				nodeCandidate = &candidate{engine: "node", version: matched}
+			}
+		}
+		if tvBunVersion != "" && bunCandidate == nil {
+			minor := resolveBunVersion(tvBunVersion)
+			if matched := matchAvailableVersion(minor, availableBunVersions); matched != "" {
+				bunCandidate = &candidate{engine: "bun", version: matched}
+			}
+		}
+	}
+
+	// 4. .bun-version
+	if bunCandidate == nil {
+		if raw, ok := files[".bun-version"]; ok {
+			if parsed := parseBunVersionFile(raw); parsed != "" {
+				minor := resolveBunVersion(parsed)
+				if matched := matchAvailableVersion(minor, availableBunVersions); matched != "" {
+					bunCandidate = &candidate{engine: "bun", version: matched}
+				}
+			}
+		}
+	}
+
+	// 5. package.json engines
+	if raw, ok := files["package.json"]; ok {
+		nodeRange, bunRange := parsePackageJSONEngines(raw)
+		if nodeCandidate == nil && nodeRange != "" {
+			if matched := matchSemverConstraint(nodeRange, availableNodeVersions); matched != "" {
+				nodeCandidate = &candidate{engine: "node", version: matched}
+			}
+		}
+		if bunCandidate == nil && bunRange != "" {
+			if matched := matchSemverConstraint(bunRange, availableBunVersions); matched != "" {
+				bunCandidate = &candidate{engine: "bun", version: matched}
+			}
+		}
+	}
+
+	// Select based on package manager tiebreaker
+	if preferBun {
+		if bunCandidate != nil {
+			return &EngineInfo{Name: bunCandidate.engine, Version: bunCandidate.version}
+		}
+		if nodeCandidate != nil {
+			return &EngineInfo{Name: nodeCandidate.engine, Version: nodeCandidate.version}
+		}
+	} else {
+		if nodeCandidate != nil {
+			return &EngineInfo{Name: nodeCandidate.engine, Version: nodeCandidate.version}
+		}
+		if bunCandidate != nil {
+			return &EngineInfo{Name: bunCandidate.engine, Version: bunCandidate.version}
+		}
+	}
+
+	// 6. Fallback: infer from package manager
+	if preferBun {
+		return &EngineInfo{Name: "bun", Version: "1.3"}
+	}
+	return &EngineInfo{Name: "node", Version: "22"}
+}

--- a/checkly/engine_rules.go
+++ b/checkly/engine_rules.go
@@ -1,0 +1,115 @@
+package checkly
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+)
+
+//go:embed engines.json
+var enginesJSON []byte
+
+type engineRule struct {
+	Source string `json:"source"`
+	Target string `json:"target"`
+	Action string `json:"action"`
+	Follow bool   `json:"follow"`
+	Notice string `json:"notice"`
+}
+
+type engineVersionConfig struct {
+	Default string       `json:"default"`
+	Rules   []engineRule `json:"rules"`
+}
+
+type engineEntry struct {
+	Name     string              `json:"name"`
+	Versions engineVersionConfig `json:"versions"`
+}
+
+type enginesFile struct {
+	Engines []engineEntry `json:"engines"`
+}
+
+var engineConfigs map[string]engineVersionConfig
+
+func init() {
+	var f enginesFile
+	if err := json.Unmarshal(enginesJSON, &f); err != nil {
+		panic(fmt.Sprintf("failed to parse embedded engines.json: %v", err))
+	}
+	engineConfigs = make(map[string]engineVersionConfig, len(f.Engines))
+	for _, e := range f.Engines {
+		engineConfigs[e.Name] = e.Versions
+	}
+}
+
+// EngineResolution is the result of resolving an engine version through the rules.
+type EngineResolution struct {
+	Version string
+	Notices []string
+	Denied  bool
+}
+
+// resolveEngineVersion resolves a version string through the engine rules.
+// It finds the first matching rule, applies the target, and follows the chain
+// if follow is true. Returns the default version if no rule matches.
+func resolveEngineVersion(version string, config engineVersionConfig) EngineResolution {
+	var notices []string
+	seen := make(map[string]bool)
+	current := version
+
+	for {
+		if seen[current] {
+			break
+		}
+		seen[current] = true
+
+		sv, err := semver.NewVersion(current)
+		if err != nil {
+			return EngineResolution{Version: config.Default, Notices: notices}
+		}
+
+		matched := false
+		for _, rule := range config.Rules {
+			c, err := semver.NewConstraint(rule.Source)
+			if err != nil {
+				continue
+			}
+			if !c.Check(sv) {
+				continue
+			}
+			matched = true
+
+			if rule.Notice != "" {
+				notice := strings.ReplaceAll(rule.Notice, "${SOURCE}", current)
+				notices = append(notices, notice)
+			}
+
+			if rule.Action == "deny" {
+				return EngineResolution{Denied: true, Notices: notices}
+			}
+
+			next := current
+			if rule.Target != "" {
+				next = rule.Target
+			}
+
+			if !rule.Follow || next == current {
+				return EngineResolution{Version: next, Notices: notices}
+			}
+
+			current = next
+			break
+		}
+
+		if !matched {
+			return EngineResolution{Version: config.Default, Notices: notices}
+		}
+	}
+
+	return EngineResolution{Version: current, Notices: notices}
+}

--- a/checkly/engine_test.go
+++ b/checkly/engine_test.go
@@ -167,26 +167,47 @@ func TestResolveBunVersion(t *testing.T) {
 	}
 }
 
-func TestMatchSemverConstraint(t *testing.T) {
+func TestResolveEngineVersion(t *testing.T) {
+	nodeConfig := engineConfigs["node"]
+	bunConfig := engineConfigs["bun"]
+
 	tests := []struct {
-		name       string
-		constraint string
-		available  []string
-		want       string
+		name        string
+		version     string
+		config      engineVersionConfig
+		wantVersion string
+		wantDenied  bool
+		wantNotice  bool
 	}{
-		{">=18 with node versions", ">=18", []string{"22", "24"}, "24"},
-		{"^22 with node versions", "^22", []string{"22", "24"}, "22"},
-		{">=25 no match", ">=25", []string{"22", "24"}, ""},
-		{">=1.0 with bun", ">=1.0", []string{"1.3"}, "1.3"},
-		{"invalid constraint", "not-valid", []string{"22"}, ""},
-		{"22 || 24", "22 || 24", []string{"22", "24"}, "24"},
+		{"node 22 allowed", "22", nodeConfig, "22", false, false},
+		{"node 24 allowed", "24", nodeConfig, "24", false, false},
+		{"node 26 allowed", "26", nodeConfig, "26", false, false},
+		{"node 18 remapped to 22 with notice", "18", nodeConfig, "22", false, true},
+		{"node 20 remapped to 22 with notice", "20", nodeConfig, "22", false, true},
+		{"node 21 remapped to 22 with notice", "21", nodeConfig, "22", false, true},
+		{"node 23 remapped to 24 with notice", "23", nodeConfig, "24", false, true},
+		{"node 25 remapped to 26 with notice", "25", nodeConfig, "26", false, true},
+		{"node 27 remapped to 26 with notice", "27", nodeConfig, "26", false, true},
+		{"node 16 remapped to 22 with notice", "16", nodeConfig, "22", false, true},
+		{"bun 1.3 allowed", "1.3", bunConfig, "1.3", false, false},
+		{"bun 1.2 remapped to 1.3 with notice", "1.2", bunConfig, "1.3", false, true},
+		{"bun 1.4 remapped to 1.3 with notice", "1.4", bunConfig, "1.3", false, true},
+		{"bun 2.0 denied", "2.0", bunConfig, "", true, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := matchSemverConstraint(tt.constraint, tt.available)
-			if got != tt.want {
-				t.Errorf("matchSemverConstraint(%q, %v) = %q, want %q",
-					tt.constraint, tt.available, got, tt.want)
+			res := resolveEngineVersion(tt.version, tt.config)
+			if res.Denied != tt.wantDenied {
+				t.Errorf("Denied = %v, want %v", res.Denied, tt.wantDenied)
+			}
+			if !tt.wantDenied && res.Version != tt.wantVersion {
+				t.Errorf("Version = %q, want %q", res.Version, tt.wantVersion)
+			}
+			if tt.wantNotice && len(res.Notices) == 0 {
+				t.Error("expected notice but got none")
+			}
+			if !tt.wantNotice && len(res.Notices) > 0 {
+				t.Errorf("expected no notice but got %v", res.Notices)
 			}
 		})
 	}
@@ -281,7 +302,7 @@ func TestDetectEngine(t *testing.T) {
 			files:          map[string][]byte{"package.json": []byte(`{"engines":{"node":">=22"}}`)},
 			packageManager: "npm",
 			wantName:       "node",
-			wantVersion:    "24",
+			wantVersion:    "26",
 		},
 		{
 			name:           "package.json engines bun",
@@ -297,21 +318,21 @@ func TestDetectEngine(t *testing.T) {
 			wantNil:        true,
 		},
 		{
-			name:           "node-version with unavailable version returns unmatched",
+			name:           "node-version with old version remaps to 22",
 			files:          map[string][]byte{".node-version": []byte("16.20.0")},
 			packageManager: "npm",
 			wantName:       "node",
-			wantVersion:    "",
+			wantVersion:    "22",
 		},
 		{
-			name:           "nvmrc with unsupported version returns unmatched",
+			name:           "nvmrc with 25 remaps to 26",
 			files:          map[string][]byte{".nvmrc": []byte("25")},
 			packageManager: "npm",
 			wantName:       "node",
-			wantVersion:    "",
+			wantVersion:    "26",
 		},
 		{
-			name:           "bun-version with unsupported version returns unmatched",
+			name:           "bun-version 2.0 denied returns empty",
 			files:          map[string][]byte{".bun-version": []byte("2.0.0")},
 			packageManager: "bun",
 			wantName:       "bun",
@@ -325,7 +346,7 @@ func TestDetectEngine(t *testing.T) {
 			},
 			packageManager: "npm",
 			wantName:       "node",
-			wantVersion:    "",
+			wantVersion:    "26",
 		},
 		{
 			name:           "nvmrc takes over when node-version absent",
@@ -341,14 +362,14 @@ func TestDetectEngine(t *testing.T) {
 			wantNil:        true,
 		},
 		{
-			name: "unmatched node-version + matched bun-version, npm PM selects unmatched node",
+			name: "node-version 25 remapped to 26, preferred over bun",
 			files: map[string][]byte{
 				".node-version": []byte("25"),
 				".bun-version":  []byte("1.3.11"),
 			},
 			packageManager: "npm",
 			wantName:       "node",
-			wantVersion:    "",
+			wantVersion:    "26",
 		},
 	}
 	for _, tt := range tests {

--- a/checkly/engine_test.go
+++ b/checkly/engine_test.go
@@ -197,6 +197,7 @@ func TestDetectEngine(t *testing.T) {
 		name           string
 		files          map[string][]byte
 		packageManager string
+		wantNil        bool
 		wantName       string
 		wantVersion    string
 	}{
@@ -242,11 +243,10 @@ func TestDetectEngine(t *testing.T) {
 			wantVersion:    "1.3",
 		},
 		{
-			name:           "nvmrc with lts skips, falls back to PM",
+			name:           "nvmrc with lts skips, returns nil",
 			files:          map[string][]byte{".nvmrc": []byte("lts/*")},
 			packageManager: "pnpm",
-			wantName:       "node",
-			wantVersion:    "22",
+			wantNil:        true,
 		},
 		{
 			name:           "tool-versions with nodejs",
@@ -291,18 +291,10 @@ func TestDetectEngine(t *testing.T) {
 			wantVersion:    "1.3",
 		},
 		{
-			name:           "no files, bun PM fallback",
+			name:           "no files, returns nil",
 			files:          map[string][]byte{},
 			packageManager: "bun",
-			wantName:       "bun",
-			wantVersion:    "1.3",
-		},
-		{
-			name:           "no files, pnpm PM fallback",
-			files:          map[string][]byte{},
-			packageManager: "pnpm",
-			wantName:       "node",
-			wantVersion:    "22",
+			wantNil:        true,
 		},
 		{
 			name:           "node-version with unavailable version returns unmatched",
@@ -343,11 +335,10 @@ func TestDetectEngine(t *testing.T) {
 			wantVersion:    "24",
 		},
 		{
-			name:           "empty node-version file falls through to PM fallback",
+			name:           "empty node-version file returns nil",
 			files:          map[string][]byte{".node-version": []byte("")},
 			packageManager: "npm",
-			wantName:       "node",
-			wantVersion:    "22",
+			wantNil:        true,
 		},
 		{
 			name: "unmatched node-version + matched bun-version, npm PM selects unmatched node",
@@ -363,6 +354,12 @@ func TestDetectEngine(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := detectEngine(tt.files, tt.packageManager)
+			if tt.wantNil {
+				if got != nil {
+					t.Errorf("detectEngine() = %+v, want nil", got)
+				}
+				return
+			}
 			if got == nil {
 				t.Fatal("detectEngine returned nil")
 			}

--- a/checkly/engine_test.go
+++ b/checkly/engine_test.go
@@ -1,0 +1,343 @@
+package checkly
+
+import (
+	"testing"
+)
+
+func TestParseNodeVersionFile(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{"full version", "22.14.0", "22.14.0"},
+		{"with v prefix", "v22.14.0", "22.14.0"},
+		{"major only", "22", "22"},
+		{"with whitespace", "  22.14.0\n", "22.14.0"},
+		{"empty", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseNodeVersionFile([]byte(tt.content))
+			if got != tt.want {
+				t.Errorf("parseNodeVersionFile(%q) = %q, want %q", tt.content, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseNvmrcFile(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{"full version", "22.14.0", "22.14.0"},
+		{"with v prefix", "v22", "22"},
+		{"lts wildcard", "lts/*", ""},
+		{"lts named", "lts/iron", ""},
+		{"lts bare", "lts", ""},
+		{"node alias", "node", ""},
+		{"stable alias", "stable", ""},
+		{"latest alias", "latest", ""},
+		{"empty", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseNvmrcFile([]byte(tt.content))
+			if got != tt.want {
+				t.Errorf("parseNvmrcFile(%q) = %q, want %q", tt.content, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseToolVersionsFile(t *testing.T) {
+	tests := []struct {
+		name       string
+		content    string
+		wantNode   string
+		wantBun    string
+	}{
+		{"nodejs entry", "nodejs 22.14.0", "22.14.0", ""},
+		{"bun entry", "bun 1.3.11", "", "1.3.11"},
+		{"multiple tools with nodejs", "python 3.12.0\nnodejs 24.1.0", "24.1.0", ""},
+		{"comments and blanks", "# comment\n\nnodejs 22.14.0", "22.14.0", ""},
+		{"both nodejs and bun", "nodejs 22.14.0\nbun 1.3.11", "22.14.0", "1.3.11"},
+		{"no match", "python 3.12.0\nruby 3.3.0", "", ""},
+		{"empty", "", "", ""},
+		{"with v prefix", "nodejs v22.14.0", "22.14.0", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotNode, gotBun := parseToolVersionsFile([]byte(tt.content))
+			if gotNode != tt.wantNode || gotBun != tt.wantBun {
+				t.Errorf("parseToolVersionsFile(%q) = (%q, %q), want (%q, %q)",
+					tt.content, gotNode, gotBun, tt.wantNode, tt.wantBun)
+			}
+		})
+	}
+}
+
+func TestParseBunVersionFile(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{"full version", "1.3.11", "1.3.11"},
+		{"major.minor", "1.3", "1.3"},
+		{"with whitespace", "  1.3.11\n", "1.3.11"},
+		{"with v prefix", "v1.3.11", "1.3.11"},
+		{"empty", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseBunVersionFile([]byte(tt.content))
+			if got != tt.want {
+				t.Errorf("parseBunVersionFile(%q) = %q, want %q", tt.content, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParsePackageJSONEngines(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		wantNode string
+		wantBun  string
+	}{
+		{"node engine", `{"engines":{"node":">=18"}}`, ">=18", ""},
+		{"bun engine", `{"engines":{"bun":">=1.0"}}`, "", ">=1.0"},
+		{"both", `{"engines":{"node":"^22","bun":">=1.3"}}`, "^22", ">=1.3"},
+		{"no engines", `{"name":"test"}`, "", ""},
+		{"malformed json", `{invalid`, "", ""},
+		{"empty", ``, "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotNode, gotBun := parsePackageJSONEngines([]byte(tt.content))
+			if gotNode != tt.wantNode || gotBun != tt.wantBun {
+				t.Errorf("parsePackageJSONEngines(%q) = (%q, %q), want (%q, %q)",
+					tt.content, gotNode, gotBun, tt.wantNode, tt.wantBun)
+			}
+		})
+	}
+}
+
+func TestResolveNodeMajorVersion(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"22.14.0", "22"},
+		{"24.1.0", "24"},
+		{"22", "22"},
+		{"", ""},
+		{"abc", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := resolveNodeMajorVersion(tt.input)
+			if got != tt.want {
+				t.Errorf("resolveNodeMajorVersion(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveBunVersion(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"1.3.11", "1.3"},
+		{"1.3", "1.3"},
+		{"1", "1"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := resolveBunVersion(tt.input)
+			if got != tt.want {
+				t.Errorf("resolveBunVersion(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMatchSemverConstraint(t *testing.T) {
+	tests := []struct {
+		name       string
+		constraint string
+		available  []string
+		want       string
+	}{
+		{">=18 with node versions", ">=18", []string{"22", "24"}, "24"},
+		{"^22 with node versions", "^22", []string{"22", "24"}, "22"},
+		{">=25 no match", ">=25", []string{"22", "24"}, ""},
+		{">=1.0 with bun", ">=1.0", []string{"1.3"}, "1.3"},
+		{"invalid constraint", "not-valid", []string{"22"}, ""},
+		{"22 || 24", "22 || 24", []string{"22", "24"}, "24"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := matchSemverConstraint(tt.constraint, tt.available)
+			if got != tt.want {
+				t.Errorf("matchSemverConstraint(%q, %v) = %q, want %q",
+					tt.constraint, tt.available, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDetectEngine(t *testing.T) {
+	tests := []struct {
+		name           string
+		files          map[string][]byte
+		packageManager string
+		wantName       string
+		wantVersion    string
+	}{
+		{
+			name:           "node-version file",
+			files:          map[string][]byte{".node-version": []byte("22.14.0")},
+			packageManager: "npm",
+			wantName:       "node",
+			wantVersion:    "22",
+		},
+		{
+			name:           "node-version with v24",
+			files:          map[string][]byte{".node-version": []byte("v24.1.0")},
+			packageManager: "pnpm",
+			wantName:       "node",
+			wantVersion:    "24",
+		},
+		{
+			name:           "bun-version file",
+			files:          map[string][]byte{".bun-version": []byte("1.3.11")},
+			packageManager: "bun",
+			wantName:       "bun",
+			wantVersion:    "1.3",
+		},
+		{
+			name: "both node-version and bun-version, npm PM prefers node",
+			files: map[string][]byte{
+				".node-version": []byte("22"),
+				".bun-version":  []byte("1.3.11"),
+			},
+			packageManager: "npm",
+			wantName:       "node",
+			wantVersion:    "22",
+		},
+		{
+			name: "both node-version and bun-version, bun PM prefers bun",
+			files: map[string][]byte{
+				".node-version": []byte("22"),
+				".bun-version":  []byte("1.3.11"),
+			},
+			packageManager: "bun",
+			wantName:       "bun",
+			wantVersion:    "1.3",
+		},
+		{
+			name:           "nvmrc with lts skips, falls back to PM",
+			files:          map[string][]byte{".nvmrc": []byte("lts/*")},
+			packageManager: "pnpm",
+			wantName:       "node",
+			wantVersion:    "22",
+		},
+		{
+			name:           "tool-versions with nodejs",
+			files:          map[string][]byte{".tool-versions": []byte("nodejs 24.1.0")},
+			packageManager: "yarn",
+			wantName:       "node",
+			wantVersion:    "24",
+		},
+		{
+			name:           "tool-versions with bun",
+			files:          map[string][]byte{".tool-versions": []byte("bun 1.3.11")},
+			packageManager: "bun",
+			wantName:       "bun",
+			wantVersion:    "1.3",
+		},
+		{
+			name:           "tool-versions with both nodejs and bun, npm PM prefers node",
+			files:          map[string][]byte{".tool-versions": []byte("nodejs 24.1.0\nbun 1.3.11")},
+			packageManager: "npm",
+			wantName:       "node",
+			wantVersion:    "24",
+		},
+		{
+			name:           "tool-versions with both nodejs and bun, bun PM prefers bun",
+			files:          map[string][]byte{".tool-versions": []byte("nodejs 24.1.0\nbun 1.3.11")},
+			packageManager: "bun",
+			wantName:       "bun",
+			wantVersion:    "1.3",
+		},
+		{
+			name:           "package.json engines node",
+			files:          map[string][]byte{"package.json": []byte(`{"engines":{"node":">=22"}}`)},
+			packageManager: "npm",
+			wantName:       "node",
+			wantVersion:    "24",
+		},
+		{
+			name:           "package.json engines bun",
+			files:          map[string][]byte{"package.json": []byte(`{"engines":{"bun":">=1.0"}}`)},
+			packageManager: "bun",
+			wantName:       "bun",
+			wantVersion:    "1.3",
+		},
+		{
+			name:           "no files, bun PM fallback",
+			files:          map[string][]byte{},
+			packageManager: "bun",
+			wantName:       "bun",
+			wantVersion:    "1.3",
+		},
+		{
+			name:           "no files, pnpm PM fallback",
+			files:          map[string][]byte{},
+			packageManager: "pnpm",
+			wantName:       "node",
+			wantVersion:    "22",
+		},
+		{
+			name:           "node-version with unavailable version falls through",
+			files:          map[string][]byte{".node-version": []byte("16.20.0")},
+			packageManager: "npm",
+			wantName:       "node",
+			wantVersion:    "22",
+		},
+		{
+			name:           "nvmrc takes over when node-version absent",
+			files:          map[string][]byte{".nvmrc": []byte("24")},
+			packageManager: "npm",
+			wantName:       "node",
+			wantVersion:    "24",
+		},
+		{
+			name:           "empty node-version file falls through",
+			files:          map[string][]byte{".node-version": []byte("")},
+			packageManager: "npm",
+			wantName:       "node",
+			wantVersion:    "22",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := detectEngine(tt.files, tt.packageManager)
+			if got == nil {
+				t.Fatal("detectEngine returned nil")
+			}
+			if got.Name != tt.wantName {
+				t.Errorf("detectEngine().Name = %q, want %q", got.Name, tt.wantName)
+			}
+			if got.Version != tt.wantVersion {
+				t.Errorf("detectEngine().Version = %q, want %q", got.Version, tt.wantVersion)
+			}
+		})
+	}
+}

--- a/checkly/engine_test.go
+++ b/checkly/engine_test.go
@@ -305,11 +305,35 @@ func TestDetectEngine(t *testing.T) {
 			wantVersion:    "22",
 		},
 		{
-			name:           "node-version with unavailable version falls through",
+			name:           "node-version with unavailable version returns unmatched",
 			files:          map[string][]byte{".node-version": []byte("16.20.0")},
 			packageManager: "npm",
 			wantName:       "node",
-			wantVersion:    "22",
+			wantVersion:    "",
+		},
+		{
+			name:           "nvmrc with unsupported version returns unmatched",
+			files:          map[string][]byte{".nvmrc": []byte("25")},
+			packageManager: "npm",
+			wantName:       "node",
+			wantVersion:    "",
+		},
+		{
+			name:           "bun-version with unsupported version returns unmatched",
+			files:          map[string][]byte{".bun-version": []byte("2.0.0")},
+			packageManager: "bun",
+			wantName:       "bun",
+			wantVersion:    "",
+		},
+		{
+			name: "nvmrc with 25 + package.json engines >=22, pinning file is authoritative",
+			files: map[string][]byte{
+				".nvmrc":       []byte("25"),
+				"package.json": []byte(`{"engines":{"node":">=22"}}`),
+			},
+			packageManager: "npm",
+			wantName:       "node",
+			wantVersion:    "",
 		},
 		{
 			name:           "nvmrc takes over when node-version absent",
@@ -319,11 +343,21 @@ func TestDetectEngine(t *testing.T) {
 			wantVersion:    "24",
 		},
 		{
-			name:           "empty node-version file falls through",
+			name:           "empty node-version file falls through to PM fallback",
 			files:          map[string][]byte{".node-version": []byte("")},
 			packageManager: "npm",
 			wantName:       "node",
 			wantVersion:    "22",
+		},
+		{
+			name: "unmatched node-version + matched bun-version, npm PM selects unmatched node",
+			files: map[string][]byte{
+				".node-version": []byte("25"),
+				".bun-version":  []byte("1.3.11"),
+			},
+			packageManager: "npm",
+			wantName:       "node",
+			wantVersion:    "",
 		},
 	}
 	for _, tt := range tests {
@@ -332,11 +366,14 @@ func TestDetectEngine(t *testing.T) {
 			if got == nil {
 				t.Fatal("detectEngine returned nil")
 			}
-			if got.Name != tt.wantName {
-				t.Errorf("detectEngine().Name = %q, want %q", got.Name, tt.wantName)
+			if got.Engine == nil {
+				t.Fatal("detectEngine().Engine is nil")
 			}
-			if got.Version != tt.wantVersion {
-				t.Errorf("detectEngine().Version = %q, want %q", got.Version, tt.wantVersion)
+			if got.Engine.Name != tt.wantName {
+				t.Errorf("detectEngine().Engine.Name = %q, want %q", got.Engine.Name, tt.wantName)
+			}
+			if got.Engine.Version != tt.wantVersion {
+				t.Errorf("detectEngine().Engine.Version = %q, want %q", got.Engine.Version, tt.wantVersion)
 			}
 		})
 	}

--- a/checkly/engines.json
+++ b/checkly/engines.json
@@ -1,0 +1,113 @@
+{
+  "engines": [
+    {
+      "name": "node",
+      "versions": {
+        "default": "22",
+        "rules": [
+          {
+            "source": "^18",
+            "target": "22",
+            "action": "allow",
+            "follow": true,
+            "notice": "Node.js 18 (LTS) is EOL since 30 Apr 2025 and no longer available. Using Node.js 22 (LTS) instead."
+          },
+          {
+            "source": "^20",
+            "target": "22",
+            "action": "allow",
+            "follow": true,
+            "notice": "Node.js 20 (LTS) is EOL since 30 Apr 2026 and no longer available. Using Node.js 22 (LTS) instead."
+          },
+          {
+            "source": "<20",
+            "target": "22",
+            "action": "allow",
+            "follow": true,
+            "notice": "Node.js ${SOURCE} is not available. Using Node.js 22 (LTS) instead."
+          },
+          {
+            "source": "^21",
+            "target": "22",
+            "action": "allow",
+            "follow": true,
+            "notice": "Node.js 21 (non-LTS) is EOL since 01 Jun 2024 and no longer available. Using Node.js 22 (LTS) instead."
+          },
+          {
+            "source": "^22",
+            "target": "22",
+            "action": "allow",
+            "follow": false
+          },
+          {
+            "source": "^23",
+            "target": "24",
+            "action": "allow",
+            "follow": true,
+            "notice": "Node.js 23 (non-LTS) is EOL since 01 Jun 2025 and no longer available. Using Node.js 24 (LTS) instead."
+          },
+          {
+            "source": "^24",
+            "target": "24",
+            "action": "allow",
+            "follow": false
+          },
+          {
+            "source": "^25",
+            "target": "26",
+            "action": "allow",
+            "follow": true,
+            "notice": "Node.js 25 (non-LTS) is EOL since 01 Jun 2026 and no longer available. Using Node.js 26 (LTS) instead."
+          },
+          {
+            "source": "^26",
+            "target": "26",
+            "action": "allow",
+            "follow": false
+          },
+          {
+            "source": ">=27",
+            "target": "26",
+            "follow": true,
+            "action": "allow",
+            "notice": "Node.js ${SOURCE} is not available yet. Using Node.js 26 (LTS) instead."
+          }
+        ]
+      }
+    },
+    {
+      "name": "bun",
+      "versions": {
+        "default": "1.3",
+        "rules": [
+          {
+            "source": "<1.3",
+            "target": "1.3",
+            "action": "allow",
+            "follow": true,
+            "notice": "Bun ${SOURCE} is not available. Using Bun 1.3 instead."
+          },
+          {
+            "source": "~1.3",
+            "target": "1.3",
+            "action": "allow",
+            "follow": false
+          },
+          {
+            "source": "^1.4",
+            "target": "1.3",
+            "action": "allow",
+            "follow": true,
+            "notice": "Bun ${SOURCE} is not available yet. Using Bun 1.3 instead."
+          },
+          {
+            "source": ">=2",
+            "action": "deny",
+            "follow": false,
+            "notice": "Bun ${SOURCE} is not available yet."
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/checkly/engines.json
+++ b/checkly/engines.json
@@ -10,28 +10,28 @@
             "target": "22",
             "action": "allow",
             "follow": true,
-            "notice": "Node.js 18 (LTS) is EOL since 30 Apr 2025 and no longer available. Using Node.js 22 (LTS) instead."
+            "notice": "Node.js 18 (LTS) is EOL since 30 Apr 2025 and no longer available. Consider Node.js 22 (LTS) instead."
           },
           {
             "source": "^20",
             "target": "22",
             "action": "allow",
             "follow": true,
-            "notice": "Node.js 20 (LTS) is EOL since 30 Apr 2026 and no longer available. Using Node.js 22 (LTS) instead."
+            "notice": "Node.js 20 (LTS) is EOL since 30 Apr 2026 and no longer available. Consider Node.js 22 (LTS) instead."
           },
           {
             "source": "<20",
             "target": "22",
             "action": "allow",
             "follow": true,
-            "notice": "Node.js ${SOURCE} is not available. Using Node.js 22 (LTS) instead."
+            "notice": "Node.js ${SOURCE} is not available. Consider Node.js 22 (LTS) instead."
           },
           {
             "source": "^21",
             "target": "22",
             "action": "allow",
             "follow": true,
-            "notice": "Node.js 21 (non-LTS) is EOL since 01 Jun 2024 and no longer available. Using Node.js 22 (LTS) instead."
+            "notice": "Node.js 21 (non-LTS) is EOL since 01 Jun 2024 and no longer available. Consider Node.js 22 (LTS) instead."
           },
           {
             "source": "^22",
@@ -44,7 +44,7 @@
             "target": "24",
             "action": "allow",
             "follow": true,
-            "notice": "Node.js 23 (non-LTS) is EOL since 01 Jun 2025 and no longer available. Using Node.js 24 (LTS) instead."
+            "notice": "Node.js 23 (non-LTS) is EOL since 01 Jun 2025 and no longer available. Consider Node.js 24 (LTS) instead."
           },
           {
             "source": "^24",
@@ -57,7 +57,7 @@
             "target": "26",
             "action": "allow",
             "follow": true,
-            "notice": "Node.js 25 (non-LTS) is EOL since 01 Jun 2026 and no longer available. Using Node.js 26 (LTS) instead."
+            "notice": "Node.js 25 (non-LTS) is EOL since 01 Jun 2026 and no longer available. Consider Node.js 26 (LTS) instead."
           },
           {
             "source": "^26",
@@ -70,7 +70,7 @@
             "target": "26",
             "follow": true,
             "action": "allow",
-            "notice": "Node.js ${SOURCE} is not available yet. Using Node.js 26 (LTS) instead."
+            "notice": "Node.js ${SOURCE} is not available yet. Consider Node.js 26 (LTS) instead."
           }
         ]
       }
@@ -85,7 +85,7 @@
             "target": "1.3",
             "action": "allow",
             "follow": true,
-            "notice": "Bun ${SOURCE} is not available. Using Bun 1.3 instead."
+            "notice": "Bun ${SOURCE} is not available. Consider Bun 1.3 instead."
           },
           {
             "source": "~1.3",
@@ -98,7 +98,7 @@
             "target": "1.3",
             "action": "allow",
             "follow": true,
-            "notice": "Bun ${SOURCE} is not available yet. Using Bun 1.3 instead."
+            "notice": "Bun ${SOURCE} is not available yet. Consider Bun 1.3 instead."
           },
           {
             "source": ">=2",

--- a/checkly/resource_playwright_check_suite.go
+++ b/checkly/resource_playwright_check_suite.go
@@ -856,6 +856,7 @@ type PlaywrightCheckSuiteRuntimeAttribute struct {
 	WorkingDir string
 	Steps      *PlaywrightCheckSuiteRuntimeStepsAttribute
 	Playwright *PlaywrightCheckSuiteRuntimePlaywrightAttribute
+	Engine     *PlaywrightCheckSuiteRuntimeEngineAttribute
 }
 
 func PlaywrightCheckSuiteRuntimeAttributeFromList(
@@ -877,11 +878,17 @@ func PlaywrightCheckSuiteRuntimeAttributeFromList(
 		return nil, err
 	}
 
+	engineAttr, err := PlaywrightCheckSuiteRuntimeEngineAttributeFromList(m["engine"].([]any))
+	if err != nil {
+		return nil, err
+	}
+
 	a := PlaywrightCheckSuiteRuntimeAttribute{
 		AutoDetect: m["auto_detect"].(bool),
 		WorkingDir: m["working_dir"].(string),
 		Steps:      stepsAttr,
 		Playwright: playwrightAttr,
+		Engine:     engineAttr,
 	}
 
 	return &a, nil
@@ -898,6 +905,7 @@ func (a *PlaywrightCheckSuiteRuntimeAttribute) ToList() []tfMap {
 			"working_dir": a.WorkingDir,
 			"steps":       a.Steps.ToList(),
 			"playwright":  a.Playwright.ToList(),
+			"engine":      a.Engine.ToList(),
 		},
 	}
 }
@@ -1089,4 +1097,30 @@ func (a *PlaywrightCheckSuiteRuntimePlaywrightDeviceAttributes) ToList() []tfMap
 	}
 
 	return m
+}
+
+type PlaywrightCheckSuiteRuntimeEngineAttribute struct {
+	Name    string
+	Version string
+}
+
+func PlaywrightCheckSuiteRuntimeEngineAttributeFromList(list []any) (*PlaywrightCheckSuiteRuntimeEngineAttribute, error) {
+	if len(list) == 0 {
+		return nil, nil
+	}
+	m := list[0].(tfMap)
+	return &PlaywrightCheckSuiteRuntimeEngineAttribute{
+		Name:    m["name"].(string),
+		Version: m["version"].(string),
+	}, nil
+}
+
+func (a *PlaywrightCheckSuiteRuntimeEngineAttribute) ToList() []tfMap {
+	if a == nil {
+		return []tfMap{}
+	}
+	return []tfMap{{
+		"name":    a.Name,
+		"version": a.Version,
+	}}
 }

--- a/checkly/resource_playwright_check_suite.go
+++ b/checkly/resource_playwright_check_suite.go
@@ -1153,19 +1153,26 @@ type PlaywrightCheckSuiteRuntimeEngineAttribute struct {
 }
 
 func PlaywrightCheckSuiteRuntimeEngineAttributeFromList(list []any) (*PlaywrightCheckSuiteRuntimeEngineAttribute, error) {
-	if len(list) == 0 {
+	if len(list) == 0 || list[0] == nil {
 		return nil, nil
 	}
 	m := list[0].(tfMap)
-	return &PlaywrightCheckSuiteRuntimeEngineAttribute{
+	attr := &PlaywrightCheckSuiteRuntimeEngineAttribute{
 		Name:    m["name"].(string),
 		Version: m["version"].(string),
-	}, nil
+	}
+	if attr.Name == "" || attr.Version == "" {
+		return nil, nil
+	}
+	return attr, nil
 }
 
 func (a *PlaywrightCheckSuiteRuntimeEngineAttribute) ToList() []tfMap {
 	if a == nil {
-		return []tfMap{}
+		return []tfMap{{
+			"name":    "",
+			"version": "",
+		}}
 	}
 	return []tfMap{{
 		"name":    a.Name,

--- a/checkly/resource_playwright_check_suite.go
+++ b/checkly/resource_playwright_check_suite.go
@@ -235,6 +235,28 @@ func resourcePlaywrightCheckSuite() *schema.Resource {
 								},
 							},
 						},
+						"engine": {
+							Description: "The JavaScript engine used to run the Playwright tests.",
+							Type:        schema.TypeList,
+							Optional:    true,
+							MaxItems:    1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Description:  `The engine name. Valid values are "node" or "bun".`,
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validateOneOf([]string{"node", "bun"}),
+									},
+									"version": {
+										Description:  `The engine version. Valid values: "22", "24" for node; "1.3" for bun.`,
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validateOneOf([]string{"22", "24", "1.3"}),
+									},
+								},
+							},
+						},
 					},
 				},
 			},

--- a/checkly/resource_playwright_check_suite.go
+++ b/checkly/resource_playwright_check_suite.go
@@ -253,7 +253,7 @@ func resourcePlaywrightCheckSuite() *schema.Resource {
 										Description:  `The engine version. Valid values: "22", "24" for node; "1.3" for bun.`,
 										Type:         schema.TypeString,
 										Required:     true,
-										ValidateFunc: validateOneOf([]string{"22", "24", "1.3"}),
+										ValidateFunc: validateOneOf(append(availableNodeVersions, availableBunVersions...)),
 									},
 								},
 							},

--- a/checkly/resource_playwright_check_suite.go
+++ b/checkly/resource_playwright_check_suite.go
@@ -500,6 +500,22 @@ func resourcePlaywrightCheckSuite() *schema.Resource {
 						}
 						overrideRuntime = true
 					}
+
+					if runtimeAttr.Engine != nil && runtimeAttr.Engine.Version == "" &&
+						bundleAttr.Metadata.EngineRawVersion != "" {
+						available := availableNodeVersions
+						if runtimeAttr.Engine.Name == "bun" {
+							available = availableBunVersions
+						}
+						return fmt.Errorf(
+							"detected %s version %q from %s, but no supported engine version matches "+
+								"(available: %s); set \"runtime.engine\" explicitly or update to a supported version",
+							runtimeAttr.Engine.Name,
+							bundleAttr.Metadata.EngineRawVersion,
+							bundleAttr.Metadata.EngineSource,
+							strings.Join(available, ", "),
+						)
+					}
 				}
 
 				if runtimeAttr.Playwright == nil || runtimeAttr.Playwright.Version == "" {

--- a/checkly/resource_playwright_check_suite.go
+++ b/checkly/resource_playwright_check_suite.go
@@ -285,6 +285,7 @@ func resourcePlaywrightCheckSuite() *schema.Resource {
 				var isRuntimeStepsInstallBlockPresent bool
 				var isRuntimeStepsTestBlockPresent bool
 				var isRuntimeStepsTestCommandPresent bool
+				var isRuntimeEngineBlockPresent bool
 
 				runtimeIt := runtimeListAttr.ElementIterator()
 				if runtimeIt.Next() {
@@ -342,6 +343,12 @@ func resourcePlaywrightCheckSuite() *schema.Resource {
 
 							isRuntimeStepsTestCommandPresent = !commandAttr.IsNull()
 						}
+					}
+
+					engineListAttr := configRuntimeAttr.GetAttr("engine")
+					engineIt := engineListAttr.ElementIterator()
+					if engineIt.Next() {
+						isRuntimeEngineBlockPresent = true
 					}
 				}
 
@@ -418,6 +425,13 @@ func resourcePlaywrightCheckSuite() *schema.Resource {
 				if !isRuntimeStepsTestCommandPresent {
 					if runtimeAttr.Steps != nil && runtimeAttr.Steps.Test != nil && runtimeAttr.Steps.Test.Command != "" {
 						runtimeAttr.Steps.Test.Command = ""
+						overrideRuntime = true
+					}
+				}
+
+				if !isRuntimeEngineBlockPresent {
+					if runtimeAttr.Engine != nil {
+						runtimeAttr.Engine = nil
 						overrideRuntime = true
 					}
 				}

--- a/checkly/resource_playwright_check_suite.go
+++ b/checkly/resource_playwright_check_suite.go
@@ -250,10 +250,10 @@ func resourcePlaywrightCheckSuite() *schema.Resource {
 										ValidateFunc: validateOneOf([]string{"node", "bun"}),
 									},
 									"version": {
-										Description:  `The engine version. Valid values: "22", "24" for node; "1.3" for bun.`,
+										Description:  `The engine version (e.g. "22", "24", "26" for node; "1.3" for bun).`,
 										Type:         schema.TypeString,
 										Required:     true,
-										ValidateFunc: validateOneOf(append(availableNodeVersions, availableBunVersions...)),
+										ValidateFunc: validateVersionFormat,
 									},
 								},
 							},
@@ -503,17 +503,12 @@ func resourcePlaywrightCheckSuite() *schema.Resource {
 
 					if runtimeAttr.Engine != nil && runtimeAttr.Engine.Version == "" &&
 						bundleAttr.Metadata.EngineRawVersion != "" {
-						available := availableNodeVersions
-						if runtimeAttr.Engine.Name == "bun" {
-							available = availableBunVersions
-						}
 						return fmt.Errorf(
-							"detected %s version %q from %s, but no supported engine version matches "+
-								"(available: %s); set \"runtime.engine\" explicitly or update to a supported version",
+							"detected %s version %q from %s, but the version was denied or could not be resolved; "+
+								"set \"runtime.engine\" explicitly or update to a supported version",
 							runtimeAttr.Engine.Name,
 							bundleAttr.Metadata.EngineRawVersion,
 							bundleAttr.Metadata.EngineSource,
-							strings.Join(available, ", "),
 						)
 					}
 				}

--- a/checkly/resource_playwright_check_suite.go
+++ b/checkly/resource_playwright_check_suite.go
@@ -239,6 +239,7 @@ func resourcePlaywrightCheckSuite() *schema.Resource {
 							Description: "The JavaScript engine used to run the Playwright tests.",
 							Type:        schema.TypeList,
 							Optional:    true,
+							Computed:    true,
 							MaxItems:    1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
@@ -490,6 +491,14 @@ func resourcePlaywrightCheckSuite() *schema.Resource {
 							testAttr.Command = defaultTestCommand
 							overrideRuntime = true
 						}
+					}
+
+					if runtimeAttr.Engine == nil && bundleAttr.Metadata.Engine != "" {
+						runtimeAttr.Engine = &PlaywrightCheckSuiteRuntimeEngineAttribute{
+							Name:    bundleAttr.Metadata.Engine,
+							Version: bundleAttr.Metadata.EngineVersion,
+						}
+						overrideRuntime = true
 					}
 				}
 

--- a/checkly/resource_playwright_check_suite.go
+++ b/checkly/resource_playwright_check_suite.go
@@ -687,6 +687,11 @@ func PlaywrightCheckSuiteResourceFromResourceData(
 				check.Browsers = browsers
 			}
 		}
+
+		if runtimeAttr.Engine != nil {
+			check.Engine = &runtimeAttr.Engine.Name
+			check.EngineVersion = &runtimeAttr.Engine.Version
+		}
 	}
 
 	resource := PlaywrightCheckSuiteResource{
@@ -758,6 +763,15 @@ func PlaywrightCheckSuiteResourceFromAPIModel(
 			}
 
 			runtimeAttr.Playwright.Devices = &devices
+		}
+	}
+
+	if check.Engine != nil && *check.Engine != "" {
+		runtimeAttr.Engine = &PlaywrightCheckSuiteRuntimeEngineAttribute{
+			Name: *check.Engine,
+		}
+		if check.EngineVersion != nil {
+			runtimeAttr.Engine.Version = *check.EngineVersion
 		}
 	}
 

--- a/checkly/resource_playwright_check_suite.go
+++ b/checkly/resource_playwright_check_suite.go
@@ -437,6 +437,19 @@ func resourcePlaywrightCheckSuite() *schema.Resource {
 					}
 				}
 
+				if isRuntimeEngineBlockPresent && runtimeAttr.Engine != nil {
+					config, ok := engineConfigs[runtimeAttr.Engine.Name]
+					if ok {
+						res := resolveEngineVersion(runtimeAttr.Engine.Version, config)
+						if res.Denied || len(res.Notices) > 0 {
+							return fmt.Errorf(
+								"\"runtime.engine.version\" is not valid: %s",
+								strings.Join(res.Notices, "; "),
+							)
+						}
+					}
+				}
+
 				if runtimeAttr.AutoDetect && bundleAttr != nil {
 					if !isRuntimeWorkingDirPresent {
 						runtimeAttr.WorkingDir = bundleAttr.Metadata.WorkingDir

--- a/checkly/resource_playwright_check_suite_test.go
+++ b/checkly/resource_playwright_check_suite_test.go
@@ -1638,3 +1638,56 @@ func TestAccPlaywrightCheckSuiteWithEngine(t *testing.T) {
 		},
 	})
 }
+
+func TestAccPlaywrightCheckSuiteEngineVersionValidation(t *testing.T) {
+	accTestCase(t, []resource.TestStep{
+		{
+			Config: playwrightCheckSuiteBase + `
+				resource "checkly_playwright_check_suite" "test" {
+					name                      = "PW Check engine validation"
+					activated                 = true
+					frequency                 = 720
+					use_global_alert_settings = true
+					locations                 = ["us-east-1"]
+
+					bundle {
+						id       = checkly_playwright_code_bundle.test.id
+						metadata = checkly_playwright_code_bundle.test.metadata
+					}
+
+					runtime {
+						engine {
+							name    = "node"
+							version = "18"
+						}
+					}
+				}
+			`,
+			ExpectError: regexp.MustCompile(`"runtime.engine.version" is not valid`),
+		},
+		{
+			Config: playwrightCheckSuiteBase + `
+				resource "checkly_playwright_check_suite" "test" {
+					name                      = "PW Check engine validation"
+					activated                 = true
+					frequency                 = 720
+					use_global_alert_settings = true
+					locations                 = ["us-east-1"]
+
+					bundle {
+						id       = checkly_playwright_code_bundle.test.id
+						metadata = checkly_playwright_code_bundle.test.metadata
+					}
+
+					runtime {
+						engine {
+							name    = "bun"
+							version = "2.0"
+						}
+					}
+				}
+			`,
+			ExpectError: regexp.MustCompile(`"runtime.engine.version" is not valid`),
+		},
+	})
+}

--- a/checkly/resource_playwright_check_suite_test.go
+++ b/checkly/resource_playwright_check_suite_test.go
@@ -1626,8 +1626,13 @@ func TestAccPlaywrightCheckSuiteWithEngine(t *testing.T) {
 			Check: resource.ComposeTestCheckFunc(
 				resource.TestCheckResourceAttr(
 					"checkly_playwright_check_suite.test",
-					"runtime.0.engine.#",
-					"0",
+					"runtime.0.engine.0.name",
+					"",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_playwright_check_suite.test",
+					"runtime.0.engine.0.version",
+					"",
 				),
 			),
 		},

--- a/checkly/resource_playwright_check_suite_test.go
+++ b/checkly/resource_playwright_check_suite_test.go
@@ -1626,13 +1626,8 @@ func TestAccPlaywrightCheckSuiteWithEngine(t *testing.T) {
 			Check: resource.ComposeTestCheckFunc(
 				resource.TestCheckResourceAttr(
 					"checkly_playwright_check_suite.test",
-					"runtime.0.engine.0.name",
-					"node",
-				),
-				resource.TestCheckResourceAttr(
-					"checkly_playwright_check_suite.test",
-					"runtime.0.engine.0.version",
-					"22",
+					"runtime.0.engine.#",
+					"0",
 				),
 			),
 		},

--- a/checkly/resource_playwright_check_suite_test.go
+++ b/checkly/resource_playwright_check_suite_test.go
@@ -1626,8 +1626,13 @@ func TestAccPlaywrightCheckSuiteWithEngine(t *testing.T) {
 			Check: resource.ComposeTestCheckFunc(
 				resource.TestCheckResourceAttr(
 					"checkly_playwright_check_suite.test",
-					"runtime.0.engine.#",
-					"0",
+					"runtime.0.engine.0.name",
+					"node",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_playwright_check_suite.test",
+					"runtime.0.engine.0.version",
+					"22",
 				),
 			),
 		},

--- a/checkly/resource_playwright_check_suite_test.go
+++ b/checkly/resource_playwright_check_suite_test.go
@@ -1532,3 +1532,104 @@ func TestAccPlaywrightCheckSuiteEnvironmentVariableRemoval(t *testing.T) {
 		},
 	})
 }
+
+func TestAccPlaywrightCheckSuiteWithEngine(t *testing.T) {
+	accTestCase(t, []resource.TestStep{
+		{
+			Config: playwrightCheckSuiteBase + `
+				resource "checkly_playwright_check_suite" "test" {
+					name                      = "PW Check with engine"
+					activated                 = true
+					frequency                 = 720
+					use_global_alert_settings = true
+					locations                 = ["us-east-1"]
+
+					bundle {
+						id       = checkly_playwright_code_bundle.test.id
+						metadata = checkly_playwright_code_bundle.test.metadata
+					}
+
+					runtime {
+						engine {
+							name    = "node"
+							version = "24"
+						}
+					}
+				}
+			`,
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr(
+					"checkly_playwright_check_suite.test",
+					"runtime.0.engine.0.name",
+					"node",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_playwright_check_suite.test",
+					"runtime.0.engine.0.version",
+					"24",
+				),
+			),
+		},
+		{
+			Config: playwrightCheckSuiteBase + `
+				resource "checkly_playwright_check_suite" "test" {
+					name                      = "PW Check with engine"
+					activated                 = true
+					frequency                 = 720
+					use_global_alert_settings = true
+					locations                 = ["us-east-1"]
+
+					bundle {
+						id       = checkly_playwright_code_bundle.test.id
+						metadata = checkly_playwright_code_bundle.test.metadata
+					}
+
+					runtime {
+						engine {
+							name    = "bun"
+							version = "1.3"
+						}
+					}
+				}
+			`,
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr(
+					"checkly_playwright_check_suite.test",
+					"runtime.0.engine.0.name",
+					"bun",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_playwright_check_suite.test",
+					"runtime.0.engine.0.version",
+					"1.3",
+				),
+			),
+		},
+		{
+			Config: playwrightCheckSuiteBase + `
+				resource "checkly_playwright_check_suite" "test" {
+					name                      = "PW Check with engine"
+					activated                 = true
+					frequency                 = 720
+					use_global_alert_settings = true
+					locations                 = ["us-east-1"]
+
+					bundle {
+						id       = checkly_playwright_code_bundle.test.id
+						metadata = checkly_playwright_code_bundle.test.metadata
+					}
+
+					runtime {
+					}
+				}
+			`,
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr(
+					"checkly_playwright_check_suite.test",
+					"runtime.0.engine.#",
+					"0",
+				),
+			),
+		},
+	})
+}

--- a/checkly/resource_playwright_code_bundle.go
+++ b/checkly/resource_playwright_code_bundle.go
@@ -132,6 +132,8 @@ func resourcePlaywrightCodeBundle() *schema.Resource {
 					bundle.Data.WorkingDir = workingDir
 					bundle.Data.Engine = lockfileInfo.Engine
 					bundle.Data.EngineVersion = lockfileInfo.EngineVersion
+					bundle.Data.EngineRawVersion = lockfileInfo.EngineRawVersion
+					bundle.Data.EngineSource = lockfileInfo.EngineSource
 
 					err = diff.SetNew(metadataAttributeName, bundle.Data.EncodeToString())
 					if err != nil {
@@ -235,7 +237,7 @@ func resourcePlaywrightCodeBundleDelete(
 	return diags
 }
 
-const PlaywrightCodeBundleMetadataCurrentVersion = 5
+const PlaywrightCodeBundleMetadataCurrentVersion = 6
 
 type PlaywrightCodeBundleMetadata struct {
 	Version           int    `json:"v"`
@@ -246,6 +248,8 @@ type PlaywrightCodeBundleMetadata struct {
 	WorkingDir        string `json:"wd,omitempty"`
 	Engine            string `json:"en,omitempty"`
 	EngineVersion     string `json:"ev,omitempty"`
+	EngineRawVersion  string `json:"erv,omitempty"`
+	EngineSource      string `json:"es,omitempty"`
 }
 
 func PlaywrightCodeBundleMetadataFromString(s string) (*PlaywrightCodeBundleMetadata, error) {
@@ -380,11 +384,13 @@ func (a *PlaywrightCodeBundlePrebuiltArchiveAttribute) ChecksumSha256() (string,
 
 // LockfileInfo contains information extracted from a lockfile found in an archive.
 type LockfileInfo struct {
-	PackageManager string
-	PackageVersion string
-	ChecksumSha256 string
-	Engine         string
-	EngineVersion  string
+	PackageManager   string
+	PackageVersion   string
+	ChecksumSha256   string
+	Engine           string
+	EngineVersion    string
+	EngineRawVersion string
+	EngineSource     string
 }
 
 type lockfileParser struct {
@@ -552,16 +558,18 @@ func (a *PlaywrightCodeBundlePrebuiltArchiveAttribute) InspectLockfile(
 		}
 	}
 
-	engineInfo := detectEngine(engineFiles, packageManager)
+	engineResult := detectEngine(engineFiles, packageManager)
 
 	info := &LockfileInfo{
 		PackageManager: packageManager,
 		PackageVersion: packageVersion,
 		ChecksumSha256: checksum,
 	}
-	if engineInfo != nil {
-		info.Engine = engineInfo.Name
-		info.EngineVersion = engineInfo.Version
+	if engineResult != nil && engineResult.Engine != nil {
+		info.Engine = engineResult.Engine.Name
+		info.EngineVersion = engineResult.Engine.Version
+		info.EngineRawVersion = engineResult.RawVersion
+		info.EngineSource = engineResult.Source
 	}
 	return info, nil
 }

--- a/checkly/resource_playwright_code_bundle.go
+++ b/checkly/resource_playwright_code_bundle.go
@@ -130,6 +130,8 @@ func resourcePlaywrightCodeBundle() *schema.Resource {
 					bundle.Data.PackageManager = lockfileInfo.PackageManager
 					bundle.Data.CacheHash = lockfileInfo.ChecksumSha256
 					bundle.Data.WorkingDir = workingDir
+					bundle.Data.Engine = lockfileInfo.Engine
+					bundle.Data.EngineVersion = lockfileInfo.EngineVersion
 
 					err = diff.SetNew(metadataAttributeName, bundle.Data.EncodeToString())
 					if err != nil {
@@ -233,7 +235,7 @@ func resourcePlaywrightCodeBundleDelete(
 	return diags
 }
 
-const PlaywrightCodeBundleMetadataCurrentVersion = 4
+const PlaywrightCodeBundleMetadataCurrentVersion = 5
 
 type PlaywrightCodeBundleMetadata struct {
 	Version           int    `json:"v"`
@@ -242,6 +244,8 @@ type PlaywrightCodeBundleMetadata struct {
 	PackageManager    string `json:"pm,omitempty"`
 	CacheHash         string `json:"ch,omitempty"`
 	WorkingDir        string `json:"wd,omitempty"`
+	Engine            string `json:"en,omitempty"`
+	EngineVersion     string `json:"ev,omitempty"`
 }
 
 func PlaywrightCodeBundleMetadataFromString(s string) (*PlaywrightCodeBundleMetadata, error) {
@@ -379,6 +383,8 @@ type LockfileInfo struct {
 	PackageManager string
 	PackageVersion string
 	ChecksumSha256 string
+	Engine         string
+	EngineVersion  string
 }
 
 type lockfileParser struct {
@@ -448,6 +454,7 @@ func (a *PlaywrightCodeBundlePrebuiltArchiveAttribute) InspectLockfile(
 		packageManager string
 		packageVersion string
 		packageJSONs   []packageJSONEntry
+		engineFiles    = make(map[string][]byte)
 	)
 
 	for {
@@ -474,8 +481,18 @@ func (a *PlaywrightCodeBundlePrebuiltArchiveAttribute) InspectLockfile(
 			continue
 		}
 
-		// Only consider lockfiles at the root of the archive.
+		// Only consider lockfiles and engine version files at the root of the archive.
 		if strings.Contains(name, "/") {
+			continue
+		}
+
+		switch name {
+		case ".node-version", ".nvmrc", ".tool-versions", ".bun-version":
+			raw, err := io.ReadAll(tr)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read %q from archive %q: %w", header.Name, a.File, err)
+			}
+			engineFiles[name] = raw
 			continue
 		}
 
@@ -527,11 +544,26 @@ func (a *PlaywrightCodeBundlePrebuiltArchiveAttribute) InspectLockfile(
 		return nil, fmt.Errorf("failed to compute archive checksum: %w", err)
 	}
 
-	return &LockfileInfo{
+	// Add root package.json to engine files for engines field detection
+	for _, entry := range packageJSONs {
+		if entry.path == "package.json" {
+			engineFiles["package.json"] = entry.raw
+			break
+		}
+	}
+
+	engineInfo := detectEngine(engineFiles, packageManager)
+
+	info := &LockfileInfo{
 		PackageManager: packageManager,
 		PackageVersion: packageVersion,
 		ChecksumSha256: checksum,
-	}, nil
+	}
+	if engineInfo != nil {
+		info.Engine = engineInfo.Name
+		info.EngineVersion = engineInfo.Version
+	}
+	return info, nil
 }
 
 func hasNodeModulesSegment(p string) bool {

--- a/checkly/resource_playwright_code_bundle_test.go
+++ b/checkly/resource_playwright_code_bundle_test.go
@@ -557,7 +557,7 @@ func TestInspectLockfileDetectsEngine(t *testing.T) {
 		}
 	})
 
-	t.Run("no version file falls back to package manager", func(t *testing.T) {
+	t.Run("no version file leaves engine empty", func(t *testing.T) {
 		t.Parallel()
 		archive := buildTarGz(t, []tarEntry{
 			{name: "package-lock.json", content: []byte(syntheticPackageLock)},
@@ -568,11 +568,11 @@ func TestInspectLockfileDetectsEngine(t *testing.T) {
 		if err != nil {
 			t.Fatalf("InspectLockfile failed: %v", err)
 		}
-		if info.Engine != "node" {
-			t.Errorf("Engine = %q, want %q", info.Engine, "node")
+		if info.Engine != "" {
+			t.Errorf("Engine = %q, want empty", info.Engine)
 		}
-		if info.EngineVersion != "22" {
-			t.Errorf("EngineVersion = %q, want %q", info.EngineVersion, "22")
+		if info.EngineVersion != "" {
+			t.Errorf("EngineVersion = %q, want empty", info.EngineVersion)
 		}
 	})
 

--- a/checkly/resource_playwright_code_bundle_test.go
+++ b/checkly/resource_playwright_code_bundle_test.go
@@ -610,8 +610,8 @@ func TestInspectLockfileDetectsEngine(t *testing.T) {
 		if info.Engine != "node" {
 			t.Errorf("Engine = %q, want %q", info.Engine, "node")
 		}
-		if info.EngineVersion != "24" {
-			t.Errorf("EngineVersion = %q, want %q", info.EngineVersion, "24")
+		if info.EngineVersion != "26" {
+			t.Errorf("EngineVersion = %q, want %q", info.EngineVersion, "26")
 		}
 	})
 }

--- a/checkly/resource_playwright_code_bundle_test.go
+++ b/checkly/resource_playwright_code_bundle_test.go
@@ -513,3 +513,105 @@ func TestInspectLockfileChecksumIncludesPackageJSON(t *testing.T) {
 		}
 	})
 }
+
+func TestInspectLockfileDetectsEngine(t *testing.T) {
+	t.Parallel()
+
+	t.Run("node-version file selects node", func(t *testing.T) {
+		t.Parallel()
+		archive := buildTarGz(t, []tarEntry{
+			{name: "package-lock.json", content: []byte(syntheticPackageLock)},
+			{name: "package.json", content: []byte(`{"name":"test","dependencies":{"@playwright/test":"1.58.2"}}`)},
+			{name: ".node-version", content: []byte("24.1.0")},
+		})
+		attr := PlaywrightCodeBundlePrebuiltArchiveAttribute{File: archive}
+		info, err := attr.InspectLockfile("@playwright/test", InspectLockfileOptions{})
+		if err != nil {
+			t.Fatalf("InspectLockfile failed: %v", err)
+		}
+		if info.Engine != "node" {
+			t.Errorf("Engine = %q, want %q", info.Engine, "node")
+		}
+		if info.EngineVersion != "24" {
+			t.Errorf("EngineVersion = %q, want %q", info.EngineVersion, "24")
+		}
+	})
+
+	t.Run("bun-version file selects bun", func(t *testing.T) {
+		t.Parallel()
+		archive := buildTarGz(t, []tarEntry{
+			{name: "bun.lock", content: []byte(`{"packages":{"":{},"@playwright/test@1.58.2":["@playwright/test@1.58.2","",{},""]}}`)},
+			{name: "package.json", content: []byte(`{"name":"test","dependencies":{"@playwright/test":"1.58.2"}}`)},
+			{name: ".bun-version", content: []byte("1.3.11")},
+		})
+		attr := PlaywrightCodeBundlePrebuiltArchiveAttribute{File: archive}
+		info, err := attr.InspectLockfile("@playwright/test", InspectLockfileOptions{})
+		if err != nil {
+			t.Fatalf("InspectLockfile failed: %v", err)
+		}
+		if info.Engine != "bun" {
+			t.Errorf("Engine = %q, want %q", info.Engine, "bun")
+		}
+		if info.EngineVersion != "1.3" {
+			t.Errorf("EngineVersion = %q, want %q", info.EngineVersion, "1.3")
+		}
+	})
+
+	t.Run("no version file falls back to package manager", func(t *testing.T) {
+		t.Parallel()
+		archive := buildTarGz(t, []tarEntry{
+			{name: "package-lock.json", content: []byte(syntheticPackageLock)},
+			{name: "package.json", content: []byte(`{"name":"test","dependencies":{"@playwright/test":"1.58.2"}}`)},
+		})
+		attr := PlaywrightCodeBundlePrebuiltArchiveAttribute{File: archive}
+		info, err := attr.InspectLockfile("@playwright/test", InspectLockfileOptions{})
+		if err != nil {
+			t.Fatalf("InspectLockfile failed: %v", err)
+		}
+		if info.Engine != "node" {
+			t.Errorf("Engine = %q, want %q", info.Engine, "node")
+		}
+		if info.EngineVersion != "22" {
+			t.Errorf("EngineVersion = %q, want %q", info.EngineVersion, "22")
+		}
+	})
+
+	t.Run("tool-versions with nodejs", func(t *testing.T) {
+		t.Parallel()
+		archive := buildTarGz(t, []tarEntry{
+			{name: "package-lock.json", content: []byte(syntheticPackageLock)},
+			{name: "package.json", content: []byte(`{"name":"test","dependencies":{"@playwright/test":"1.58.2"}}`)},
+			{name: ".tool-versions", content: []byte("nodejs 24.1.0\npython 3.12.0")},
+		})
+		attr := PlaywrightCodeBundlePrebuiltArchiveAttribute{File: archive}
+		info, err := attr.InspectLockfile("@playwright/test", InspectLockfileOptions{})
+		if err != nil {
+			t.Fatalf("InspectLockfile failed: %v", err)
+		}
+		if info.Engine != "node" {
+			t.Errorf("Engine = %q, want %q", info.Engine, "node")
+		}
+		if info.EngineVersion != "24" {
+			t.Errorf("EngineVersion = %q, want %q", info.EngineVersion, "24")
+		}
+	})
+
+	t.Run("package.json engines.node", func(t *testing.T) {
+		t.Parallel()
+		archive := buildTarGz(t, []tarEntry{
+			{name: "package-lock.json", content: []byte(syntheticPackageLock)},
+			{name: "package.json", content: []byte(`{"name":"test","dependencies":{"@playwright/test":"1.58.2"},"engines":{"node":">=22"}}`)},
+		})
+		attr := PlaywrightCodeBundlePrebuiltArchiveAttribute{File: archive}
+		info, err := attr.InspectLockfile("@playwright/test", InspectLockfileOptions{})
+		if err != nil {
+			t.Fatalf("InspectLockfile failed: %v", err)
+		}
+		if info.Engine != "node" {
+			t.Errorf("Engine = %q, want %q", info.Engine, "node")
+		}
+		if info.EngineVersion != "24" {
+			t.Errorf("EngineVersion = %q, want %q", info.EngineVersion, "24")
+		}
+	})
+}

--- a/checkly/validation.go
+++ b/checkly/validation.go
@@ -4,6 +4,7 @@ import (
 	"cmp"
 	"fmt"
 	"os"
+	"regexp"
 	"slices"
 )
 
@@ -89,4 +90,14 @@ func validateAll(validators ...func(any, string) ([]string, []error)) func(any, 
 		}
 		return warns, errs
 	}
+}
+
+var versionFormatRegex = regexp.MustCompile(`^\d+(\.\d+){0,2}$`)
+
+func validateVersionFormat(val any, key string) (warns []string, errs []error) {
+	v := val.(string)
+	if !versionFormatRegex.MatchString(v) {
+		errs = append(errs, fmt.Errorf("%q must be a version number (e.g. \"22\", \"24\", \"1.3\"), got: %s", key, v))
+	}
+	return warns, errs
 }

--- a/docs/resources/playwright_check_suite.md
+++ b/docs/resources/playwright_check_suite.md
@@ -230,9 +230,19 @@ Optional:
 Optional:
 
 - `auto_detect` (Boolean) Whether to automatically detect appropriate runtime environment configuration from the bundle. (Default `true`).
+- `engine` (Block List, Max: 1) The JavaScript engine used to run the Playwright tests. (see [below for nested schema](#nestedblock--runtime--engine))
 - `playwright` (Block List, Max: 1) Configure the Playwright capabilities that should be made available to the runtime environment. (see [below for nested schema](#nestedblock--runtime--playwright))
 - `steps` (Block List, Max: 1) Customize the actions taken during test execution. (see [below for nested schema](#nestedblock--runtime--steps))
 - `working_dir` (String) The working directory in which runtime commands are executed. This is useful for monorepos or workspaces where the Playwright project is in a subdirectory. Use "." to explicitly specify the root.
+
+<a id="nestedblock--runtime--engine"></a>
+### Nested Schema for `runtime.engine`
+
+Required:
+
+- `name` (String) The engine name. Valid values are "node" or "bun".
+- `version` (String) The engine version (e.g. "22", "24", "26" for node; "1.3" for bun).
+
 
 <a id="nestedblock--runtime--playwright"></a>
 ### Nested Schema for `runtime.playwright`

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,10 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.38.2
 )
 
-require gopkg.in/yaml.v3 v3.0.1
+require (
+	github.com/Masterminds/semver/v3 v3.2.0
+	gopkg.in/yaml.v3 v3.0.1
+)
 
 require (
 	cel.dev/expr v0.24.0 // indirect
@@ -28,7 +31,6 @@ require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.50.0 // indirect
 	github.com/Kunde21/markdownfmt/v3 v3.1.0 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
-	github.com/Masterminds/semver/v3 v3.2.0 // indirect
 	github.com/Masterminds/sprig/v3 v3.2.3 // indirect
 	github.com/ProtonMail/go-crypto v1.4.1 // indirect
 	github.com/agext/levenshtein v1.2.3 // indirect

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.8
 
 require (
 	github.com/aws/aws-sdk-go v1.44.122 // indirect
-	github.com/checkly/checkly-go-sdk v1.20.2
+	github.com/checkly/checkly-go-sdk v1.20.3
 	github.com/google/go-cmp v0.7.0
 	github.com/gruntwork-io/terratest v0.41.16
 	github.com/hashicorp/terraform-plugin-docs v0.25.0

--- a/go.sum
+++ b/go.sum
@@ -251,8 +251,8 @@ github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghf
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/checkly/checkly-go-sdk v1.20.2 h1:SZCmj9Jtxlq760jtZWV5nsA/Q19r075xgVtVuwC3CmA=
-github.com/checkly/checkly-go-sdk v1.20.2/go.mod h1:Pd6tBOggAe41NnCU5KwqA8JvD6J20/IctszT2E0AvHo=
+github.com/checkly/checkly-go-sdk v1.20.3 h1:3DZ/mfcpbdshR9/G2UHEnxHJzj8B9kj/rHYDP0CNkbE=
+github.com/checkly/checkly-go-sdk v1.20.3/go.mod h1:Pd6tBOggAe41NnCU5KwqA8JvD6J20/IctszT2E0AvHo=
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=


### PR DESCRIPTION
## Summary

Adds an `engine` block to the `runtime` block of the `checkly_playwright_check_suite` resource, allowing users to select which JavaScript engine (Node.js or Bun) and version runs their Playwright tests.

### Manual selection

```hcl
runtime {
  engine {
    name    = "node"   # or "bun"
    version = "24"     # or "22", "26", "1.3"
  }
}
```

### Automatic detection

When `auto_detect = true` (default) and no explicit `engine` block is set, the engine is auto-detected from the code bundle by checking (in priority order):

1. `.node-version`
2. `.nvmrc` (skips `lts/*` aliases)
3. `.tool-versions` (`nodejs` / `bun` entries)
4. `.bun-version`
5. `package.json` `engines.node` / `engines.bun` (semver range matching)

When no version file is found, engine defaults to `null` — the runner chooses.

Pinning files are authoritative: if `.nvmrc` specifies an unsupported version, it is silently remapped to the nearest available version.

### Version resolution

Versions are resolved through embedded `engines.json` rules:
- EOL Node versions are remapped (e.g., Node 18 → 22, Node 21 → 22)
- Non-LTS versions are remapped to current LTS (e.g., Node 23 → 24, Node 25 → 26)
- Future/unavailable versions are remapped to latest available
- Bun < 1.3 remapped to 1.3; Bun >= 2 is denied
- Invalid or unsupported versions are rejected at plan time with a clear error message

### Changes

- **Schema:** `engine` block under `runtime` with `name` and `version` fields (`Computed: true` for auto-detection)
- **Version resolution:** `engines.json` embedded with semver range matching, target rewriting, follow chains, deny actions
- **Explicit version validation:** User-specified versions are checked against rules at plan time
- **SDK wiring:** Maps engine block to/from `PlaywrightCheck.Engine`/`EngineVersion`
- **CustomizeDiff:** Clearing when block removed (empty-string sentinel for SDK v2 compat), auto-detection from bundle metadata, error on denied version
- **Detection core:** Parsers for 5 file types, priority cascade with per-engine candidate tracking
- **Archive inspection:** Collects version files during bundle scan, stores in metadata v6
- **Tests:** Rule resolution tests, detection integration tests, acceptance tests (create/update/remove, version validation)

## Depends on

- **SDK:** checkly/checkly-go-sdk#156 (merged, SDK v1.20.3)
- **Backend:** checkly/monorepo#1817 — adds engine/engineVersion fields to the Checkly API

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./checkly -count=1` — all unit/integration tests pass
- [ ] `TF_ACC=1 go test ./checkly -run TestAccPlaywrightCheckSuiteWithEngine -v` — acceptance test
- [ ] `TF_ACC=1 go test ./checkly -run TestAccPlaywrightCheckSuiteEngineVersionValidation -v` — validation test