### PR TITLE
feat: slack app alert channel

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,7 +71,7 @@ After you have installed Terraform and Go, you can clone the repository and star
   $ go mod tidy
   ```
 
-4. Run build process to ensure that everyhing is on place
+4. Run build process to ensure that everything is on place
   ```sh
   $ go build
   ```

--- a/checkly/resource_alert_channel.go
+++ b/checkly/resource_alert_channel.go
@@ -17,6 +17,8 @@ const (
 	AcFieldSlack                = "slack"
 	AcFieldSlackURL             = "url"
 	AcFieldSlackChannel         = "channel"
+	AcFieldSlackApp             = "slack_app"
+	AcFieldSlackAppChannels     = "slack_channels"
 	AcFieldSMS                  = "sms"
 	AcFieldSMSName              = "name"
 	AcFieldSMSNumber            = "number"
@@ -88,9 +90,10 @@ func resourceAlertChannel() *schema.Resource {
 				},
 			},
 			AcFieldSlack: {
-				Type:     schema.TypeSet,
-				Optional: true,
-				MaxItems: 1,
+				Type:       schema.TypeSet,
+				Optional:   true,
+				MaxItems:   1,
+				Deprecated: "The `slack` block uses the legacy Slack webhook integration and will be removed in a future major release. Use `slack_app` instead.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						AcFieldSlackURL: {
@@ -102,6 +105,22 @@ func resourceAlertChannel() *schema.Resource {
 							Type:        schema.TypeString,
 							Required:    true,
 							Description: "The name of the alert's Slack channel",
+						},
+					},
+				},
+			},
+			AcFieldSlackApp: {
+				Type:     schema.TypeSet,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						AcFieldSlackAppChannels: {
+							Type:        schema.TypeList,
+							Required:    true,
+							MinItems:    1,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: "The Slack channels or users to notify, e.g. `[\"#ops\", \"@John\"]`.",
 						},
 					},
 				},
@@ -359,6 +378,7 @@ func resourceDataFromAlertChannel(it *checkly.AlertChannel, d *schema.ResourceDa
 	d.Set(AcFieldSMS, setFromSMS(it.SMS))
 	d.Set(AcFieldCall, setFromCall(it.CALL))
 	d.Set(AcFieldSlack, setFromSlack(it.Slack))
+	d.Set(AcFieldSlackApp, setFromSlackApp(it.SlackApp))
 	d.Set(AcFieldWebhook, setFromWebhook(it.Webhook))
 	d.Set(AcFieldOpsgenie, setFromOpsgenie(it.Opsgenie))
 	d.Set(AcFieldPagerduty, setFromPagerduty(it.Pagerduty))
@@ -407,7 +427,7 @@ func alertChannelFromResourceData(d *schema.ResourceData) (checkly.AlertChannel,
 		ac.SSLExpiryThreshold = &i
 	}
 
-	fields := []string{AcFieldEmail, AcFieldSMS, AcFieldCall, AcFieldSlack, AcFieldWebhook, AcFieldOpsgenie, AcFieldPagerduty}
+	fields := []string{AcFieldEmail, AcFieldSMS, AcFieldCall, AcFieldSlack, AcFieldSlackApp, AcFieldWebhook, AcFieldOpsgenie, AcFieldPagerduty}
 	setCount := 0
 	for _, field := range fields {
 		cfgSet := (d.Get(field)).(*schema.Set)
@@ -451,6 +471,15 @@ func alertChannelConfigFromSet(channelType string, s *schema.Set) (interface{}, 
 		return &checkly.AlertChannelSlack{
 			Channel:    cfg[AcFieldSlackChannel].(string),
 			WebhookURL: cfg[AcFieldSlackURL].(string),
+		}, nil
+	case checkly.AlertTypeSlackApp:
+		raw := cfg[AcFieldSlackAppChannels].([]interface{})
+		channels := make([]string, 0, len(raw))
+		for _, v := range raw {
+			channels = append(channels, v.(string))
+		}
+		return &checkly.AlertChannelSlackApp{
+			SlackChannels: channels,
 		}, nil
 	case checkly.AlertTypeOpsgenie:
 		return &checkly.AlertChannelOpsgenie{
@@ -523,6 +552,21 @@ func setFromSlack(cfg *checkly.AlertChannelSlack) []tfMap {
 		{
 			AcFieldSlackChannel: cfg.Channel,
 			AcFieldSlackURL:     cfg.WebhookURL,
+		},
+	}
+}
+
+func setFromSlackApp(cfg *checkly.AlertChannelSlackApp) []tfMap {
+	if cfg == nil {
+		return []tfMap{}
+	}
+	channels := make([]interface{}, 0, len(cfg.SlackChannels))
+	for _, c := range cfg.SlackChannels {
+		channels = append(channels, c)
+	}
+	return []tfMap{
+		{
+			AcFieldSlackAppChannels: channels,
 		},
 	}
 }

--- a/checkly/resource_alert_channel_test.go
+++ b/checkly/resource_alert_channel_test.go
@@ -72,6 +72,23 @@ func TestAccSlack(t *testing.T) {
 	})
 }
 
+func TestAccSlackApp(t *testing.T) {
+	accTestCase(t, []resource.TestStep{
+		{
+			Config: `resource "checkly_alert_channel" "slack_app_ac" {
+				slack_app {
+					slack_channels = ["#ops", "@John"]
+				}
+				send_recovery        = true
+				send_failure         = true
+				send_degraded        = false
+				ssl_expiry           = true
+				ssl_expiry_threshold = 11
+			}`,
+		},
+	})
+}
+
 func TestAccSMS(t *testing.T) {
 	accTestCase(t, []resource.TestStep{
 		{

--- a/checkly/resource_alert_channel_test.go
+++ b/checkly/resource_alert_channel_test.go
@@ -3,6 +3,7 @@ package checkly
 import (
 	"fmt"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -73,11 +74,11 @@ func TestAccSlack(t *testing.T) {
 }
 
 func TestAccSlackApp(t *testing.T) {
-	accTestCase(t, []resource.TestStep{
+	accTestCaseWithErrorCheck(t, []resource.TestStep{
 		{
 			Config: `resource "checkly_alert_channel" "slack_app_ac" {
 				slack_app {
-					slack_channels = ["#ops", "@John"]
+					slack_channels = ["#terraform-e2e-slack-app-alert-target"]
 				}
 				send_recovery        = true
 				send_failure         = true
@@ -86,6 +87,15 @@ func TestAccSlackApp(t *testing.T) {
 				ssl_expiry_threshold = 11
 			}`,
 		},
+	}, func(err error) error {
+		// A SLACK_APP alert channel can only be created on accounts that have
+		// connected the Checkly Slack App. Without it the API responds with a
+		// slack_integration_not_connected error, which is account setup rather
+		// than a provider defect, so skip instead of failing.
+		if err != nil && strings.Contains(err.Error(), "slack_integration_not_connected") {
+			t.Skipf("Slack App integration is not connected on this account; skipping: %v", err)
+		}
+		return err
 	})
 }
 

--- a/checkly/test_util.go
+++ b/checkly/test_util.go
@@ -31,12 +31,21 @@ func testAccPreCheck(t *testing.T) {
 }
 
 func accTestCase(t *testing.T, steps []resource.TestStep) {
+	accTestCaseWithErrorCheck(t, steps, nil)
+}
+
+// accTestCaseWithErrorCheck behaves like accTestCase but routes any step error
+// through errorCheck before the framework reports it. This lets a test skip
+// when the account lacks setup the test depends on (e.g. a connected
+// integration) rather than failing.
+func accTestCaseWithErrorCheck(t *testing.T, steps []resource.TestStep, errorCheck resource.ErrorCheckFunc) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: nil,
+		ErrorCheck:   errorCheck,
 		Steps:        steps,
 	})
 }

--- a/demo/alert-channels.tf
+++ b/demo/alert-channels.tf
@@ -10,6 +10,18 @@ resource "checkly_alert_channel" "email_ac" {
 }
 
 # Slack Alert Channel
+resource "checkly_alert_channel" "slack_app_ac" {
+  slack_app {
+    slack_channels = ["#ops", "@John"]
+  }
+  send_recovery        = true
+  send_failure         = true
+  send_degraded        = false
+  ssl_expiry           = true
+  ssl_expiry_threshold = 11
+}
+
+# Slack Alert Channel
 resource "checkly_alert_channel" "slack_ac" {
   slack {
     channel = "checkly_alerts"

--- a/demo/alert-channels.tf
+++ b/demo/alert-channels.tf
@@ -9,7 +9,7 @@ resource "checkly_alert_channel" "email_ac" {
   ssl_expiry    = false
 }
 
-# Slack Alert Channel
+# Slack App Alert Channel
 resource "checkly_alert_channel" "slack_app_ac" {
   slack_app {
     slack_channels = ["#ops", "@John"]

--- a/docs/resources/alert_channel.md
+++ b/docs/resources/alert_channel.md
@@ -35,7 +35,15 @@ resource "checkly_alert_channel" "sms_ac" {
   send_failure  = true
 }
 
-# A Slack alert channel
+# A Slack App alert channel, using the Checkly Slack App
+resource "checkly_alert_channel" "slack_app_ac" {
+  slack_app {
+    slack_channels = ["#checkly-notifications", "@john"]
+  }
+}
+
+# A legacy Slack alert channel, using a Slack webhook URL.
+# Deprecated: use the slack_app block instead.
 resource "checkly_alert_channel" "slack_ac" {
   slack {
     channel = "#checkly-notifications"

--- a/docs/resources/alert_channel.md
+++ b/docs/resources/alert_channel.md
@@ -176,7 +176,8 @@ resource "checkly_check" "example_check" {
 - `send_degraded` (Boolean) (Default `false`)
 - `send_failure` (Boolean) (Default `true`)
 - `send_recovery` (Boolean) (Default `true`)
-- `slack` (Block Set, Max: 1) (see [below for nested schema](#nestedblock--slack))
+- `slack` (Block Set, Max: 1, Deprecated) (see [below for nested schema](#nestedblock--slack))
+- `slack_app` (Block Set, Max: 1) (see [below for nested schema](#nestedblock--slack_app))
 - `sms` (Block Set, Max: 1) (see [below for nested schema](#nestedblock--sms))
 - `ssl_expiry` (Boolean) (Default `false`)
 - `ssl_expiry_threshold` (Number) Value must be between 1 and 30 (Default `30`)
@@ -234,6 +235,14 @@ Required:
 
 - `channel` (String) The name of the alert's Slack channel
 - `url` (String) The Slack webhook URL
+
+
+<a id="nestedblock--slack_app"></a>
+### Nested Schema for `slack_app`
+
+Required:
+
+- `slack_channels` (List of String) The Slack channels or users to notify, e.g. `["#ops", "@John"]`.
 
 
 <a id="nestedblock--sms"></a>

--- a/examples/resources/checkly_alert_channel/resource.tf
+++ b/examples/resources/checkly_alert_channel/resource.tf
@@ -20,7 +20,15 @@ resource "checkly_alert_channel" "sms_ac" {
   send_failure  = true
 }
 
-# A Slack alert channel
+# A Slack App alert channel, using the Checkly Slack App
+resource "checkly_alert_channel" "slack_app_ac" {
+  slack_app {
+    slack_channels = ["#checkly-notifications", "@john"]
+  }
+}
+
+# A legacy Slack alert channel, using a Slack webhook URL.
+# Deprecated: use the slack_app block instead.
 resource "checkly_alert_channel" "slack_ac" {
   slack {
     channel = "#checkly-notifications"

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.8
 
 require (
 	github.com/aws/aws-sdk-go v1.44.122 // indirect
-	github.com/checkly/checkly-go-sdk v1.20.3
+	github.com/checkly/checkly-go-sdk v1.21.0
 	github.com/google/go-cmp v0.7.0
 	github.com/gruntwork-io/terratest v0.41.16
 	github.com/hashicorp/terraform-plugin-docs v0.25.0

--- a/go.sum
+++ b/go.sum
@@ -251,8 +251,8 @@ github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghf
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/checkly/checkly-go-sdk v1.20.3 h1:3DZ/mfcpbdshR9/G2UHEnxHJzj8B9kj/rHYDP0CNkbE=
-github.com/checkly/checkly-go-sdk v1.20.3/go.mod h1:Pd6tBOggAe41NnCU5KwqA8JvD6J20/IctszT2E0AvHo=
+github.com/checkly/checkly-go-sdk v1.21.0 h1:yWxedr1bxx/GEGl9djvBFs6K+4NgIMTgMTDqvMKHKvc=
+github.com/checkly/checkly-go-sdk v1.21.0/go.mod h1:Pd6tBOggAe41NnCU5KwqA8JvD6J20/IctszT2E0AvHo=
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=


### PR DESCRIPTION
## Affected Components
* [x] Resources
* [x] Test
* [x] Docs
* [ ] Tooling
* [ ] Other

## Pre-Requisites
* [x] Terraform code is formatted with `terraform fmt`
* [x] Go code is formatted with `go fmt`
* [ ] `plan` & `apply` command of `demo/main.tf` file do not produce diffs

## Notes for the Reviewer

- adds Slack App alert channel (`slack_app` block with `slack_channels`)
- marks the legacy `slack` alert channel as deprecated
- requires `checkly-go-sdk` v1.21.0 (now released), which provides the `AlertChannelSlackApp` / `AlertTypeSlackApp` types; `go.mod` is bumped accordingly so the provider builds against the released SDK
