### PR TITLE
feat: include .npmrc in Playwright code bundle checksum [RED-691]

### DIFF
--- a/checkly/resource_playwright_code_bundle.go
+++ b/checkly/resource_playwright_code_bundle.go
@@ -426,15 +426,22 @@ type packageJSONEntry struct {
 	raw  []byte
 }
 
+type npmrcEntry struct {
+	path string
+	raw  []byte
+}
+
 // InspectLockfile opens the tar.gz archive and searches for a lockfile
 // (package-lock.json, pnpm-lock.yaml, yarn.lock, or bun.lock) at the root
 // of the archive. If found, it returns the detected package manager and
 // the resolved version of the given package.
 //
-// ChecksumSha256 covers both the lockfile contents and every package.json
-// outside node_modules (at any depth). Each package.json is canonicalized
-// as JSON with opts.PackageJSONExcludedFields removed from the top level,
-// so cosmetic changes and excluded fields don't influence the checksum.
+// ChecksumSha256 covers the lockfile contents, every package.json outside
+// node_modules (at any depth), and every .npmrc outside node_modules. Each
+// package.json is canonicalized as JSON with opts.PackageJSONExcludedFields
+// removed from the top level, so cosmetic changes and excluded fields don't
+// influence the checksum. .npmrc files contribute the raw SHA-256 of their
+// bytes, so any change to registry configuration invalidates the checksum.
 func (a *PlaywrightCodeBundlePrebuiltArchiveAttribute) InspectLockfile(
 	packageName string,
 	opts InspectLockfileOptions,
@@ -460,6 +467,7 @@ func (a *PlaywrightCodeBundlePrebuiltArchiveAttribute) InspectLockfile(
 		packageManager string
 		packageVersion string
 		packageJSONs   []packageJSONEntry
+		npmrcs         []npmrcEntry
 		engineFiles    = make(map[string][]byte)
 	)
 
@@ -484,6 +492,15 @@ func (a *PlaywrightCodeBundlePrebuiltArchiveAttribute) InspectLockfile(
 				return nil, fmt.Errorf("failed to read %q from archive %q: %w", header.Name, a.File, err)
 			}
 			packageJSONs = append(packageJSONs, packageJSONEntry{path: name, raw: raw})
+			continue
+		}
+
+		if path.Base(name) == ".npmrc" && !hasNodeModulesSegment(name) {
+			raw, err := io.ReadAll(tr)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read %q from archive %q: %w", header.Name, a.File, err)
+			}
+			npmrcs = append(npmrcs, npmrcEntry{path: name, raw: raw})
 			continue
 		}
 
@@ -545,7 +562,7 @@ func (a *PlaywrightCodeBundlePrebuiltArchiveAttribute) InspectLockfile(
 		return nil, nil
 	}
 
-	checksum, err := composeBundleChecksum(lockfileName, lockfileHash, packageJSONs, opts.PackageJSONExcludedFields)
+	checksum, err := composeBundleChecksum(lockfileName, lockfileHash, packageJSONs, npmrcs, opts.PackageJSONExcludedFields)
 	if err != nil {
 		return nil, fmt.Errorf("failed to compute archive checksum: %w", err)
 	}
@@ -593,17 +610,29 @@ func canonicalizePackageJSON(raw []byte, excludedFields []string) ([]byte, error
 	return json.Marshal(obj)
 }
 
-// composeBundleChecksum combines the lockfile hash and every canonicalized
-// package.json (sorted by path) into a single SHA-256. Records are
-// length-prefixed to prevent collisions from ambiguous concatenation.
+// composeBundleChecksum combines the lockfile hash, every canonicalized
+// package.json, and every .npmrc (each set sorted by path) into a single
+// SHA-256. Records are length-prefixed to prevent collisions from ambiguous
+// concatenation.
+//
+// This must stay byte-for-byte compatible with the Checkly CLI's
+// composeCacheHash (packages/cli/src/services/check-parser/cache-hash.ts):
+// same record framing, same label prefixes, and the same record order —
+// lockfile, then package.json records (sorted), then npmrc records (sorted).
+// An .npmrc record's content is the raw SHA-256 digest of the file bytes
+// (not canonicalized, unlike package.json), matching the CLI.
 func composeBundleChecksum(
 	lockfileName string,
 	lockfileHash []byte,
 	packageJSONs []packageJSONEntry,
+	npmrcs []npmrcEntry,
 	excludedFields []string,
 ) (string, error) {
 	sort.Slice(packageJSONs, func(i, j int) bool {
 		return packageJSONs[i].path < packageJSONs[j].path
+	})
+	sort.Slice(npmrcs, func(i, j int) bool {
+		return npmrcs[i].path < npmrcs[j].path
 	})
 
 	h := sha256.New()
@@ -625,6 +654,11 @@ func composeBundleChecksum(
 			return "", fmt.Errorf("failed to canonicalize %q: %w", entry.path, err)
 		}
 		writeRecord("package.json:"+entry.path, canonical)
+	}
+
+	for _, entry := range npmrcs {
+		sum := sha256.Sum256(entry.raw)
+		writeRecord("npmrc:"+entry.path, sum[:])
 	}
 
 	return hex.EncodeToString(h.Sum(nil)), nil

--- a/checkly/resource_playwright_code_bundle_test.go
+++ b/checkly/resource_playwright_code_bundle_test.go
@@ -3,6 +3,7 @@ package checkly
 import (
 	"archive/tar"
 	"compress/gzip"
+	"crypto/sha256"
 	"errors"
 	"os"
 	"path/filepath"
@@ -505,6 +506,154 @@ func TestInspectLockfileChecksumIncludesPackageJSON(t *testing.T) {
 		b := buildTarGz(t, []tarEntry{
 			{"packages/e2e/package.json", nestedPkg},
 			{"package.json", rootPkg},
+			{"package-lock.json", []byte(syntheticPackageLock)},
+		})
+
+		if inspectWithExcludedVersion(t, a).ChecksumSha256 != inspectWithExcludedVersion(t, b).ChecksumSha256 {
+			t.Error("checksum should be stable regardless of tar entry order")
+		}
+	})
+}
+
+// TestComposeBundleChecksumNpmrcCrossLanguageParity pins the checksum against
+// digests produced by the Checkly CLI's composeCacheHash
+// (packages/cli/src/services/check-parser/cache-hash.ts) for the exact same
+// records. The CLI and this provider must compute identical bundle checksums so
+// the backend reuses one cached dependency-install layer regardless of which
+// tool deployed the Playwright Check Suite. If either constant below changes,
+// the two implementations have diverged — reconcile them, do not just update
+// the constant.
+func TestComposeBundleChecksumNpmrcCrossLanguageParity(t *testing.T) {
+	t.Parallel()
+
+	lockHash := sha256.Sum256([]byte("lock-bytes"))
+	pkgs := []packageJSONEntry{{path: "package.json", raw: []byte(`{"name":"root"}`)}}
+	npmrcs := []npmrcEntry{
+		{path: ".npmrc", raw: []byte("registry=https://example.com/\n")},
+		{path: "packages/app/.npmrc", raw: []byte("@scope:registry=https://npm.example.com/\n")},
+	}
+
+	const (
+		wantWithNpmrc = "59c13ea869c6b9730ed183aeb880959bd98de1f17fc44ca426cd7c53a6afa148"
+		wantNoNpmrc   = "dd362bae9c06091691f72b3a73e4f5f4d4861518629e85ed9fd08221d655f204"
+	)
+
+	got, err := composeBundleChecksum("package-lock.json", lockHash[:], pkgs, npmrcs, []string{"version"})
+	if err != nil {
+		t.Fatalf("composeBundleChecksum: %v", err)
+	}
+	if got != wantWithNpmrc {
+		t.Errorf("checksum with .npmrc = %q, want %q (diverged from Checkly CLI)", got, wantWithNpmrc)
+	}
+
+	// Omitting .npmrc must be a no-op relative to a bundle that never had one,
+	// matching the CLI (which writes zero npmrc records when there are none).
+	gotNoNpmrc, err := composeBundleChecksum("package-lock.json", lockHash[:], pkgs, nil, []string{"version"})
+	if err != nil {
+		t.Fatalf("composeBundleChecksum: %v", err)
+	}
+	if gotNoNpmrc != wantNoNpmrc {
+		t.Errorf("checksum without .npmrc = %q, want %q (diverged from Checkly CLI)", gotNoNpmrc, wantNoNpmrc)
+	}
+	if got == gotNoNpmrc {
+		t.Error("adding .npmrc records should change the checksum")
+	}
+}
+
+func TestInspectLockfileChecksumIncludesNpmrc(t *testing.T) {
+	t.Parallel()
+
+	t.Run("adding an .npmrc changes the checksum", func(t *testing.T) {
+		t.Parallel()
+
+		a := buildTarGz(t, []tarEntry{
+			{"package-lock.json", []byte(syntheticPackageLock)},
+			{"package.json", []byte(`{"name":"root"}`)},
+		})
+		b := buildTarGz(t, []tarEntry{
+			{"package-lock.json", []byte(syntheticPackageLock)},
+			{"package.json", []byte(`{"name":"root"}`)},
+			{".npmrc", []byte("registry=https://example.com/\n")},
+		})
+
+		if inspectWithExcludedVersion(t, a).ChecksumSha256 == inspectWithExcludedVersion(t, b).ChecksumSha256 {
+			t.Error("adding an .npmrc should change the checksum")
+		}
+	})
+
+	t.Run("editing an .npmrc changes the checksum", func(t *testing.T) {
+		t.Parallel()
+
+		a := buildTarGz(t, []tarEntry{
+			{"package-lock.json", []byte(syntheticPackageLock)},
+			{"package.json", []byte(`{"name":"root"}`)},
+			{".npmrc", []byte("registry=https://a.example.com/\n")},
+		})
+		b := buildTarGz(t, []tarEntry{
+			{"package-lock.json", []byte(syntheticPackageLock)},
+			{"package.json", []byte(`{"name":"root"}`)},
+			{".npmrc", []byte("registry=https://b.example.com/\n")},
+		})
+
+		if inspectWithExcludedVersion(t, a).ChecksumSha256 == inspectWithExcludedVersion(t, b).ChecksumSha256 {
+			t.Error("changing .npmrc content should change the checksum")
+		}
+	})
+
+	t.Run("a nested .npmrc outside node_modules is included", func(t *testing.T) {
+		t.Parallel()
+
+		a := buildTarGz(t, []tarEntry{
+			{"package-lock.json", []byte(syntheticPackageLock)},
+			{"package.json", []byte(`{"name":"root"}`)},
+			{".npmrc", []byte("registry=https://example.com/\n")},
+		})
+		b := buildTarGz(t, []tarEntry{
+			{"package-lock.json", []byte(syntheticPackageLock)},
+			{"package.json", []byte(`{"name":"root"}`)},
+			{".npmrc", []byte("registry=https://example.com/\n")},
+			{"packages/app/.npmrc", []byte("@scope:registry=https://npm.example.com/\n")},
+		})
+
+		if inspectWithExcludedVersion(t, a).ChecksumSha256 == inspectWithExcludedVersion(t, b).ChecksumSha256 {
+			t.Error("a nested .npmrc should change the checksum")
+		}
+	})
+
+	t.Run("an .npmrc inside node_modules is ignored", func(t *testing.T) {
+		t.Parallel()
+
+		a := buildTarGz(t, []tarEntry{
+			{"package-lock.json", []byte(syntheticPackageLock)},
+			{"package.json", []byte(`{"name":"root"}`)},
+		})
+		b := buildTarGz(t, []tarEntry{
+			{"package-lock.json", []byte(syntheticPackageLock)},
+			{"package.json", []byte(`{"name":"root"}`)},
+			{"node_modules/some-pkg/.npmrc", []byte("registry=https://example.com/\n")},
+		})
+
+		if inspectWithExcludedVersion(t, a).ChecksumSha256 != inspectWithExcludedVersion(t, b).ChecksumSha256 {
+			t.Error("an .npmrc inside node_modules should not contribute to the checksum")
+		}
+	})
+
+	t.Run("tar entry order does not affect the checksum", func(t *testing.T) {
+		t.Parallel()
+
+		rootNpmrc := []byte("registry=https://example.com/\n")
+		nestedNpmrc := []byte("@scope:registry=https://npm.example.com/\n")
+
+		a := buildTarGz(t, []tarEntry{
+			{"package-lock.json", []byte(syntheticPackageLock)},
+			{"package.json", []byte(`{"name":"root"}`)},
+			{".npmrc", rootNpmrc},
+			{"packages/app/.npmrc", nestedNpmrc},
+		})
+		b := buildTarGz(t, []tarEntry{
+			{"packages/app/.npmrc", nestedNpmrc},
+			{".npmrc", rootNpmrc},
+			{"package.json", []byte(`{"name":"root"}`)},
 			{"package-lock.json", []byte(syntheticPackageLock)},
 		})
 


### PR DESCRIPTION
Linear: RED-691

## What & why

The Checkly CLI now folds `.npmrc` files into the Playwright bundle cache hash (checkly/checkly-cli#1394). This PR mirrors that in the provider so both tools compute a **byte-identical** bundle checksum for a bundle that contains `.npmrc` files. Without it, a project deployed via both the CLI and Terraform would compute different checksums once it has an `.npmrc`, causing the backend to miss the shared cached dependency-install layer.

`.npmrc` matters because it carries registry configuration (alternate/private registries, auth) that the cloud `install` needs to resolve dependencies.

## How

- `InspectLockfile` now collects every `.npmrc` outside `node_modules` from the archive (any depth), mirroring the existing `package.json` collection.
- `composeBundleChecksum` emits `npmrc:<path>` records **after** the `package.json` records, sorted by path, with the **raw SHA-256 of the file bytes** as content (not canonicalized — unlike `package.json`). Record order is lockfile → package.json → npmrc, matching the CLI's `composeCacheHash`.
- Bundles without any `.npmrc` produce a byte-identical checksum to before (zero `npmrc:` records).

## Testing

- A cross-language parity test pins the checksum against two digests computed directly from the CLI's `composeCacheHash` (with and without `.npmrc`), so any future drift between the two implementations fails loudly.
- Archive-level tests: adding/editing an `.npmrc` changes the checksum, a nested `.npmrc` is included, `node_modules/.npmrc` is ignored, and tar-entry order doesn't matter.
- `go build`, `go vet`, `gofmt`, and the full `checkly` package tests pass.
