### PR TITLE
fix(test): use E.164 +-prefixed SMS number for new backend validation [RED-693]

### DIFF
--- a/checkly/resource_alert_channel_test.go
+++ b/checkly/resource_alert_channel_test.go
@@ -105,7 +105,7 @@ func TestAccSMS(t *testing.T) {
 			Config: `resource "checkly_alert_channel" "sms_ac" {
 				sms {
 					name   = "smsalerts"
-					number = "4917512345678"
+					number = "+4917512345678"
 				}
 			}`,
 		},

--- a/demo/alert-channels.tf
+++ b/demo/alert-channels.tf
@@ -38,7 +38,7 @@ resource "checkly_alert_channel" "slack_ac" {
 resource "checkly_alert_channel" "sms_ac" {
   sms {
     name   = "smsalerts"
-    number = "4917512345678"
+    number = "+4917512345678"
   }
 }
 


### PR DESCRIPTION
Linear: RED-693

## Problem

The Checkly backend tightened phone-number validation and now rejects an SMS `number` without a `+` country-code prefix, returning HTTP 400 "Invalid country code" on `config.number`. This made `TestAccSMS` fail. The failure is pre-existing and backend-driven — it reproduces on `main`, independent of any provider change.

## Fix

Add the E.164 `+` prefix (`4917512345678` → `+4917512345678`) so the backend can parse the country code:

- `checkly/resource_alert_channel_test.go` (`TestAccSMS`)
- `demo/alert-channels.tf` (`sms_ac` block) — keeps the demo consistent with its `call` block and the examples/docs, which already use `+`-prefixed numbers.

The provider passes the number through verbatim, so no non-test code change is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)