### PR TITLE
ci: update all GitHub Actions to latest and pin to commit SHAs [RED-812]

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -27,11 +27,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -42,7 +42,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v4
+      uses: github/codeql-action/autobuild@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -56,4 +56,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,27 +9,26 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       -
         name: Unshallow
         run: git fetch --prune --unshallow
       -
         name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: 1.26
       -
         name: Import GPG key
         id: import_gpg
-        uses: paultyng/ghaction-import-gpg@v2.1.0
-        env:
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-          PASSPHRASE: ${{ secrets.PASSPHRASE }}
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.PASSPHRASE }}
       -
         name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v4
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
-          version: latest
           args: release --clean
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}

--- a/.github/workflows/terraform-format-and-style.yml
+++ b/.github/workflows/terraform-format-and-style.yml
@@ -12,15 +12,15 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-    - uses: actions/checkout@v6
-    - uses: hashicorp/setup-terraform@v4
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+    - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
 
     - name: terraform fmt
       id: fmt
       run: terraform fmt -check -recursive -diff
       continue-on-error: true
 
-    - uses: actions/github-script@v9
+    - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       if: github.event_name == 'pull_request'
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,12 +20,12 @@ jobs:
     timeout-minutes: 5
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
       with:
         go-version: '1.26'
       id: go
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v6
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Get dependencies
       run: |
         go mod download
@@ -37,10 +37,10 @@ jobs:
     name: Go generate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: '1.26'
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - run: go generate ./...
       - name: git diff
         run: |
@@ -68,25 +68,25 @@ jobs:
           - '1.1.*'
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
       with:
         go-version: '1.26'
       id: go
 
-    - uses: hashicorp/setup-terraform@v4
+    - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
       with:
         terraform_version: ${{ matrix.terraform }}
         terraform_wrapper: false
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v6
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Get dependencies
       run: |
         go mod download
 
     - name: Set up gotestfmt
-      uses: gotesttools/gotestfmt-action@v2
+      uses: gotesttools/gotestfmt-action@eba2ac97f623e866e7b1b117c99f18b43cd36d18 # v2.3.0
 
     - name: TF acceptance tests
       timeout-minutes: 10
@@ -107,7 +107,7 @@ jobs:
     - name: Sanitize artifact name
       id: artifact-name
       if: always()
-      uses: actions/github-script@v9
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       with:
         result-encoding: string
         script: |
@@ -115,7 +115,7 @@ jobs:
           return `test-log-tf-${tf}`
 
     - name: Upload test log
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: always()
       with:
         name: ${{ steps.artifact-name.outputs.result }}


### PR DESCRIPTION
Linear: RED-812

## What

Updates every GitHub Action used in `.github/workflows/` to its latest release and pins each reference to the full commit SHA of that release, with a trailing `# vX.Y.Z` comment. Mutable version tags are a supply-chain risk: a compromised action repository can retag and inject code into CI. Dependabot natively supports SHA-pinned actions and keeps both the SHA and the version comment updated, so the existing daily update config keeps working unchanged.

| Action | Before | After |
|---|---|---|
| actions/checkout | v6 | v7.0.1 |
| actions/setup-go | v6 | v7.0.0 |
| actions/github-script | v9 | v9.0.0 |
| actions/upload-artifact | v7 | v7.0.1 |
| github/codeql-action/* | v4 | v4.37.3 |
| hashicorp/setup-terraform | v4 | v4.0.1 |
| goreleaser/goreleaser-action | v4 | v7.2.3 |
| gotesttools/gotestfmt-action | v2 | v2.3.0 |
| paultyng/ghaction-import-gpg | v2.1.0 | crazy-max/ghaction-import-gpg v7.0.0 |

## Breaking changes handled

- **`release.yml`: `paultyng/ghaction-import-gpg` → `crazy-max/ghaction-import-gpg@v7`.** The paultyng action is its abandoned ancestor (last tag 2019, node12-era runtime); crazy-max's is the maintained successor used by HashiCorp's current provider scaffolding. The secrets move from `env:` vars to `with:` inputs (`gpg_private_key`, `passphrase`); the `fingerprint` output keeps its name, so the GoReleaser step's `GPG_FINGERPRINT` wiring is unchanged.
- **`release.yml`: goreleaser-action v4 → v7.** `version: latest` is dropped so the action's `~> v2` default applies — `.goreleaser.yml` already declares `version: 2`, and this prevents a future GoReleaser v3 release from being picked up silently.
- **checkout v6 → v7** blocks fork-PR checkout under `pull_request_target`/`workflow_run` triggers; no workflow here uses those, so no changes were needed.

## Verification

- Every pinned SHA was resolved from its release tag via the GitHub API (through annotated tag objects where applicable) and matches what's in the files.
- `actionlint` passes on all four workflows.
- **Residual risk:** `release.yml` only runs on `v*` tags, so the import-gpg migration cannot be exercised pre-merge. Input/output names were verified against the crazy-max v7.0.0 `action.yml`; worth watching the first tagged release after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
