### PR TITLE
feat: add timezone and pause/silence scope to the maintenance window resource

### DIFF
--- a/checkly/resource_maintenance_window.go
+++ b/checkly/resource_maintenance_window.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
@@ -79,6 +80,46 @@ func resourceMaintenanceWindow() *schema.Resource {
 				},
 				Description: "The names of the checks and groups maintenance window should apply to.",
 			},
+			"timezone": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The named IANA time zone used for recurring maintenance scheduling, e.g. `America/New_York`. UTC offset identifiers such as `+05:00` are not accepted. Defaults to UTC.",
+				ValidateFunc: func(value interface{}, key string) (warns []string, errs []error) {
+					v := value.(string)
+					if v == "" {
+						return warns, errs
+					}
+					// Mirror the backend's IANA validation so an invalid zone
+					// fails at plan time rather than as an opaque API error.
+					if _, err := time.LoadLocation(v); err != nil {
+						errs = append(errs, fmt.Errorf("%q must be a valid IANA time zone, got %s", key, v))
+					}
+					return warns, errs
+				},
+			},
+			"pause_all_checks": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "When true, checks are paused for every check in the account, regardless of `tags`.",
+			},
+			"silence_alerts_tags": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				DefaultFunc: func() (interface{}, error) {
+					return []tfMap{}, nil
+				},
+				Description: "The tags that determine which checks have their alerts silenced. Ignored when `silence_all_alerts` is true.",
+			},
+			"silence_all_alerts": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "When true, alerts are silenced for every check in the account, overriding `silence_alerts_tags`.",
+			},
 		},
 	}
 }
@@ -91,15 +132,23 @@ func maintenanceWindowsFromResourceData(d *schema.ResourceData) (checkly.Mainten
 		}
 		ID = 0
 	}
+	// Taken by address so an explicit false is sent rather than omitted.
+	pauseAllChecks := d.Get("pause_all_checks").(bool)
+	silenceAllAlerts := d.Get("silence_all_alerts").(bool)
+
 	a := checkly.MaintenanceWindow{
-		ID:             ID,
-		Name:           d.Get("name").(string),
-		StartsAt:       d.Get("starts_at").(string),
-		EndsAt:         d.Get("ends_at").(string),
-		RepeatUnit:     d.Get("repeat_unit").(string),
-		RepeatEndsAt:   d.Get("repeat_ends_at").(string),
-		RepeatInterval: d.Get("repeat_interval").(int),
-		Tags:           stringsFromSet(d.Get("tags").(*schema.Set)),
+		ID:                ID,
+		Name:              d.Get("name").(string),
+		StartsAt:          d.Get("starts_at").(string),
+		EndsAt:            d.Get("ends_at").(string),
+		RepeatUnit:        d.Get("repeat_unit").(string),
+		RepeatEndsAt:      d.Get("repeat_ends_at").(string),
+		RepeatInterval:    d.Get("repeat_interval").(int),
+		Tags:              stringsFromSet(d.Get("tags").(*schema.Set)),
+		Timezone:          d.Get("timezone").(string),
+		PauseAllChecks:    &pauseAllChecks,
+		SilenceAlertsTags: stringsFromSet(d.Get("silence_alerts_tags").(*schema.Set)),
+		SilenceAllAlerts:  &silenceAllAlerts,
 	}
 
 	fmt.Printf("%v", a)
@@ -115,6 +164,11 @@ func resourceDataFromMaintenanceWindows(s *checkly.MaintenanceWindow, d *schema.
 	d.Set("repeat_ends_at", s.RepeatEndsAt)
 	d.Set("repeat_interval", s.RepeatInterval)
 	d.Set("tags", s.Tags)
+	d.Set("timezone", s.Timezone)
+	// Both are *bool, so guard the dereference: a nil pointer would panic.
+	d.Set("pause_all_checks", s.PauseAllChecks != nil && *s.PauseAllChecks)
+	d.Set("silence_alerts_tags", s.SilenceAlertsTags)
+	d.Set("silence_all_alerts", s.SilenceAllAlerts != nil && *s.SilenceAllAlerts)
 	return nil
 }
 

--- a/checkly/resource_maintenance_window_test.go
+++ b/checkly/resource_maintenance_window_test.go
@@ -1,0 +1,99 @@
+package checkly
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccMaintenanceWindowInvalidTimezone(t *testing.T) {
+	accTestCase(t, []resource.TestStep{
+		{
+			Config: `
+				resource "checkly_maintenance_windows" "test" {
+					name      = "foo"
+					starts_at = "2014-08-24T00:00:00.000Z"
+					ends_at   = "2014-08-25T00:00:00.000Z"
+					timezone  = "+05:00"
+				}
+			`,
+			ExpectError: regexp.MustCompile(`must be a valid IANA time zone`),
+		},
+	})
+}
+
+func TestAccMaintenanceWindowScopes(t *testing.T) {
+	rInt := acctest.RandInt()
+	accTestCase(t, []resource.TestStep{
+		{
+			Config: fmt.Sprintf(`
+				resource "checkly_maintenance_windows" "test" {
+					name           = "maintenance-%d"
+					starts_at      = "2014-08-24T00:00:00.000Z"
+					ends_at        = "2014-08-25T00:00:00.000Z"
+					timezone       = "America/New_York"
+					tags           = ["production"]
+
+					silence_alerts_tags = ["production", "staging"]
+				}
+			`, rInt),
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr(
+					"checkly_maintenance_windows.test",
+					"timezone",
+					"America/New_York",
+				),
+				// Both booleans default to false and must round-trip as false
+				// rather than being dropped from the payload.
+				resource.TestCheckResourceAttr(
+					"checkly_maintenance_windows.test",
+					"pause_all_checks",
+					"false",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_maintenance_windows.test",
+					"silence_all_alerts",
+					"false",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_maintenance_windows.test",
+					"silence_alerts_tags.#",
+					"2",
+				),
+			),
+		},
+		{
+			// Account-wide scope: tags become irrelevant on both sides.
+			Config: fmt.Sprintf(`
+				resource "checkly_maintenance_windows" "test" {
+					name               = "maintenance-%d"
+					starts_at          = "2014-08-24T00:00:00.000Z"
+					ends_at            = "2014-08-25T00:00:00.000Z"
+					timezone           = "Europe/Berlin"
+					pause_all_checks   = true
+					silence_all_alerts = true
+				}
+			`, rInt),
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr(
+					"checkly_maintenance_windows.test",
+					"timezone",
+					"Europe/Berlin",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_maintenance_windows.test",
+					"pause_all_checks",
+					"true",
+				),
+				resource.TestCheckResourceAttr(
+					"checkly_maintenance_windows.test",
+					"silence_all_alerts",
+					"true",
+				),
+			),
+		},
+	})
+}

--- a/docs/resources/maintenance_windows.md
+++ b/docs/resources/maintenance_windows.md
@@ -20,9 +20,26 @@ resource "checkly_maintenance_windows" "maintenance-1" {
   repeat_unit     = "MONTH"
   repeat_ends_at  = "2014-08-24T00:00:00.000Z"
   repeat_interval = 1
+  timezone        = "America/New_York"
   tags = [
     "production"
   ]
+
+  # Silence alerts for a wider set of checks than the ones being paused.
+  silence_alerts_tags = [
+    "production",
+    "staging"
+  ]
+}
+
+# Pause and silence every check in the account, ignoring tags entirely.
+resource "checkly_maintenance_windows" "maintenance-account-wide" {
+  name               = "Account-wide maintenance"
+  starts_at          = "2014-08-24T00:00:00.000Z"
+  ends_at            = "2014-08-25T00:00:00.000Z"
+  timezone           = "Europe/Berlin"
+  pause_all_checks   = true
+  silence_all_alerts = true
 }
 ```
 
@@ -37,10 +54,14 @@ resource "checkly_maintenance_windows" "maintenance-1" {
 
 ### Optional
 
+- `pause_all_checks` (Boolean) When true, checks are paused for every check in the account, regardless of `tags`.
 - `repeat_ends_at` (String) The date on which the maintenance window should stop repeating.
 - `repeat_interval` (Number) The repeat interval of the maintenance window from the first occurrence.
 - `repeat_unit` (String) The repeat cadence for the maintenance window. Possible values `DAY`, `WEEK` and `MONTH`.
+- `silence_alerts_tags` (Set of String) The tags that determine which checks have their alerts silenced. Ignored when `silence_all_alerts` is true.
+- `silence_all_alerts` (Boolean) When true, alerts are silenced for every check in the account, overriding `silence_alerts_tags`.
 - `tags` (Set of String) The names of the checks and groups maintenance window should apply to.
+- `timezone` (String) The named IANA time zone used for recurring maintenance scheduling, e.g. `America/New_York`. UTC offset identifiers such as `+05:00` are not accepted. Defaults to UTC.
 
 ### Read-Only
 

--- a/examples/resources/checkly_maintenance_windows/resource.tf
+++ b/examples/resources/checkly_maintenance_windows/resource.tf
@@ -5,7 +5,24 @@ resource "checkly_maintenance_windows" "maintenance-1" {
   repeat_unit     = "MONTH"
   repeat_ends_at  = "2014-08-24T00:00:00.000Z"
   repeat_interval = 1
+  timezone        = "America/New_York"
   tags = [
     "production"
   ]
+
+  # Silence alerts for a wider set of checks than the ones being paused.
+  silence_alerts_tags = [
+    "production",
+    "staging"
+  ]
+}
+
+# Pause and silence every check in the account, ignoring tags entirely.
+resource "checkly_maintenance_windows" "maintenance-account-wide" {
+  name               = "Account-wide maintenance"
+  starts_at          = "2014-08-24T00:00:00.000Z"
+  ends_at            = "2014-08-25T00:00:00.000Z"
+  timezone           = "Europe/Berlin"
+  pause_all_checks   = true
+  silence_all_alerts = true
 }


### PR DESCRIPTION
**BLOCKED: do not merge until checkly/checkly-go-sdk#170 is released and `go.mod` is bumped to that version.** — https://github.com/checkly/checkly-go-sdk/pull/170

Written and built against a local `replace` pointing at the unreleased SDK; the directive has been dropped and `go.mod` still pins `checkly-go-sdk v1.22.0`.

**Adds `timezone`, `pause_all_checks`, `silence_alerts_tags` and `silence_all_alerts`** — all four already exist on the public API but had no Terraform representation.

**`timezone` validates at plan time.** The backend rejects non-IANA zones, so the schema mirrors that with `time.LoadLocation` — `timezone = "+05:00"` now fails during plan instead of returning an opaque API error.

**Adds the acceptance test file this resource never had.** It had no test coverage at all; the new file covers both scope combinations and the timezone rejection.

**Docs are regenerated**, not hand-edited.
