### PR TITLE
feat: add path attribute to checkly_client_certificate [RED-722]

### DIFF
--- a/checkly/resource_client_certificate.go
+++ b/checkly/resource_client_certificate.go
@@ -67,7 +67,8 @@ func resourceClientCertificate() *schema.Resource {
 				Description: "Optional URL path prefix that limits the certificate to requests under that path, " +
 					"e.g. `/partner/api`. Matching is on whole path segments: `/partner` applies to `/partner` and " +
 					"`/partner/orders` but not to `/partnership`. Must start with `/` and must not be a bare `/`; a " +
-					"trailing `/` is ignored. Only API check requests are matched on path. Omit it to use the " +
+					"trailing `/` is ignored. API checks and Multistep checks match on path; gRPC, SSL and TCP " +
+					"monitors only use certificates without a path. Omit it to use the " +
 					"certificate for every path on the host.",
 			},
 			"certificate": {

--- a/checkly/resource_client_certificate.go
+++ b/checkly/resource_client_certificate.go
@@ -23,9 +23,10 @@ func resourceClientCertificate() *schema.Resource {
 			"or any other authentication scheme where the requester needs to " +
 			"provide a certificate." +
 			"\n\n" +
-			"Each client certificate is specific to a domain name, e.g. " +
-			"`acme.com` and will be used automatically by any API checks " +
-			"targeting that domain." +
+			"Each client certificate is specific to a host name, e.g. " +
+			"`acme.com` or a wildcard such as `*.acme.com`, and will be used " +
+			"automatically by any API checks targeting that host. Set `path` " +
+			"to limit the certificate to requests under a URL path prefix." +
 			"\n\n" +
 			"Changing the value of any attribute forces a new resource to " +
 			"be created.",
@@ -34,7 +35,40 @@ func resourceClientCertificate() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				Description: "The host domain that the certificate should be used for.",
+				Description: "The host domain that the certificate should be used for. Wildcards are supported, e.g. `*.acme.com`.",
+			},
+			"path": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				// The API stores the path without a trailing slash. Normalizing
+				// the planned value the same way keeps config and state equal,
+				// otherwise "/partner/api/" would force a replacement on every
+				// apply.
+				StateFunc: func(v interface{}) string {
+					return strings.TrimSuffix(v.(string), "/")
+				},
+				// The API refuses these too; failing at plan time is clearer
+				// than an apply error, and a bare "/" would otherwise be
+				// trimmed to an empty path and silently sent as "no path".
+				ValidateFunc: func(v interface{}, key string) ([]string, []error) {
+					p := v.(string)
+					if p == "" {
+						return nil, nil
+					}
+					if !strings.HasPrefix(p, "/") {
+						return nil, []error{fmt.Errorf("%q must start with \"/\"", key)}
+					}
+					if strings.TrimSuffix(p, "/") == "" {
+						return nil, []error{fmt.Errorf("%q must name a path below \"/\"; omit it to match every path", key)}
+					}
+					return nil, nil
+				},
+				Description: "Optional URL path prefix that limits the certificate to requests under that path, " +
+					"e.g. `/partner/api`. Matching is on whole path segments: `/partner` applies to `/partner` and " +
+					"`/partner/orders` but not to `/partnership`. Must start with `/` and must not be a bare `/`; a " +
+					"trailing `/` is ignored. Only API check requests are matched on path. Omit it to use the " +
+					"certificate for every path on the host.",
 			},
 			"certificate": {
 				Type:        schema.TypeString,
@@ -84,6 +118,7 @@ func clientCertificateFromResourceData(d *schema.ResourceData) (checkly.ClientCe
 	return checkly.ClientCertificate{
 		ID:          d.Id(),
 		Host:        d.Get("host").(string),
+		Path:        d.Get("path").(string),
 		Certificate: d.Get("certificate").(string),
 		PrivateKey:  d.Get("private_key").(string),
 		Passphrase:  d.Get("passphrase").(string),
@@ -93,6 +128,7 @@ func clientCertificateFromResourceData(d *schema.ResourceData) (checkly.ClientCe
 
 func resourceDataFromClientCertificate(c *checkly.ClientCertificate, d *schema.ResourceData) error {
 	d.Set("host", c.Host)
+	d.Set("path", c.Path)
 	d.Set("certificate", c.Certificate)
 	// The backend does not return a value for PrivateKey anymore, though it
 	// used to. The value should not change by itself, so we can simply keep

--- a/checkly/resource_client_certificate_test.go
+++ b/checkly/resource_client_certificate_test.go
@@ -29,6 +29,7 @@ func TestAccClientCertificate(t *testing.T) {
 	config := `
 resource "checkly_client_certificate" "test" {
   host = "*.acme.com"
+  path = "/partner/api/"
 
   certificate = <<-EOT
 			-----BEGIN CERTIFICATE-----
@@ -84,6 +85,12 @@ resource "checkly_client_certificate" "test" {
 					"checkly_client_certificate.test",
 					"host",
 					"*.acme.com",
+				),
+				// The API drops the trailing slash the config spells out.
+				resource.TestCheckResourceAttr(
+					"checkly_client_certificate.test",
+					"path",
+					"/partner/api",
 				),
 				resource.TestCheckResourceAttr(
 					"checkly_client_certificate.test",

--- a/docs/resources/client_certificate.md
+++ b/docs/resources/client_certificate.md
@@ -46,7 +46,7 @@ resource "checkly_client_certificate" "test" {
 ### Optional
 
 - `passphrase` (String, Sensitive) Passphrase for the private key.
-- `path` (String) Optional URL path prefix that limits the certificate to requests under that path, e.g. `/partner/api`. Matching is on whole path segments: `/partner` applies to `/partner` and `/partner/orders` but not to `/partnership`. Must start with `/` and must not be a bare `/`; a trailing `/` is ignored. Only API check requests are matched on path. Omit it to use the certificate for every path on the host.
+- `path` (String) Optional URL path prefix that limits the certificate to requests under that path, e.g. `/partner/api`. Matching is on whole path segments: `/partner` applies to `/partner` and `/partner/orders` but not to `/partnership`. Must start with `/` and must not be a bare `/`; a trailing `/` is ignored. API checks and Multistep checks match on path; gRPC, SSL and TCP monitors only use certificates without a path. Omit it to use the certificate for every path on the host.
 - `trusted_ca` (String) PEM formatted bundle of CA certificates that the client should trust. The bundle may contain many CA certificates.
 
 ### Read-Only

--- a/docs/resources/client_certificate.md
+++ b/docs/resources/client_certificate.md
@@ -4,7 +4,7 @@ page_title: "checkly_client_certificate Resource - terraform-provider-checkly"
 subcategory: ""
 description: |-
   Use client certificates to authenticate your API checks to APIs that require mutual TLS (mTLS) authentication, or any other authentication scheme where the requester needs to provide a certificate.
-  Each client certificate is specific to a domain name, e.g. acme.com and will be used automatically by any API checks targeting that domain.
+  Each client certificate is specific to a host name, e.g. acme.com or a wildcard such as *.acme.com, and will be used automatically by any API checks targeting that host. Set path to limit the certificate to requests under a URL path prefix.
   Changing the value of any attribute forces a new resource to be created.
 ---
 
@@ -12,7 +12,7 @@ description: |-
 
 Use client certificates to authenticate your API checks to APIs that require mutual TLS (mTLS) authentication, or any other authentication scheme where the requester needs to provide a certificate.
 
-Each client certificate is specific to a domain name, e.g. `acme.com` and will be used automatically by any API checks targeting that domain.
+Each client certificate is specific to a host name, e.g. `acme.com` or a wildcard such as `*.acme.com`, and will be used automatically by any API checks targeting that host. Set `path` to limit the certificate to requests under a URL path prefix.
 
 Changing the value of any attribute forces a new resource to be created.
 
@@ -26,6 +26,7 @@ variable "acme_client_certificate_passphrase" {
 
 resource "checkly_client_certificate" "test" {
   host        = "*.acme.com"
+  path        = "/partner/api" # optional: only requests under this path use the certificate
   certificate = file("${path.module}/cert.pem")
   private_key = file("${path.module}/key.pem")
   trusted_ca  = file("${path.module}/ca.pem")
@@ -39,12 +40,13 @@ resource "checkly_client_certificate" "test" {
 ### Required
 
 - `certificate` (String) The client certificate in PEM format.
-- `host` (String) The host domain that the certificate should be used for.
+- `host` (String) The host domain that the certificate should be used for. Wildcards are supported, e.g. `*.acme.com`.
 - `private_key` (String) The private key for the certificate in PEM format.
 
 ### Optional
 
 - `passphrase` (String, Sensitive) Passphrase for the private key.
+- `path` (String) Optional URL path prefix that limits the certificate to requests under that path, e.g. `/partner/api`. Matching is on whole path segments: `/partner` applies to `/partner` and `/partner/orders` but not to `/partnership`. Must start with `/` and must not be a bare `/`; a trailing `/` is ignored. Only API check requests are matched on path. Omit it to use the certificate for every path on the host.
 - `trusted_ca` (String) PEM formatted bundle of CA certificates that the client should trust. The bundle may contain many CA certificates.
 
 ### Read-Only

--- a/examples/resources/checkly_client_certificate/resource.tf
+++ b/examples/resources/checkly_client_certificate/resource.tf
@@ -5,6 +5,7 @@ variable "acme_client_certificate_passphrase" {
 
 resource "checkly_client_certificate" "test" {
   host        = "*.acme.com"
+  path        = "/partner/api" # optional: only requests under this path use the certificate
   certificate = file("${path.module}/cert.pem")
   private_key = file("${path.module}/key.pem")
   trusted_ca  = file("${path.module}/ca.pem")

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/checkly/terraform-provider-checkly
 go 1.26.0
 
 require (
-	github.com/checkly/checkly-go-sdk v1.22.0
+	github.com/checkly/checkly-go-sdk v1.23.0
 	github.com/google/go-cmp v0.7.0
 	github.com/hashicorp/terraform-plugin-docs v0.25.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.1

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,8 @@ github.com/bufbuild/protocompile v0.14.1 h1:iA73zAf/fyljNjQKwYzUHD6AD4R8KMasmwa/
 github.com/bufbuild/protocompile v0.14.1/go.mod h1:ppVdAIhbr2H8asPk6k4pY7t9zB1OU5DoEw9xY/FUi1c=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/checkly/checkly-go-sdk v1.22.0 h1:Hl3xa5zc7QtxFCSFtfJJ/Uq7GDzUDKbTWtCRcKeF9Fc=
-github.com/checkly/checkly-go-sdk v1.22.0/go.mod h1:pndYEiaO8wC5Ztyn1PMeNtFVKFQUqZGzwcUmbgIG3Do=
+github.com/checkly/checkly-go-sdk v1.23.0 h1:s81+4UTmzoDRv5dWJGdWYJLRMAiTSUm3t9oUGnZdEuQ=
+github.com/checkly/checkly-go-sdk v1.23.0/go.mod h1:pndYEiaO8wC5Ztyn1PMeNtFVKFQUqZGzwcUmbgIG3Do=
 github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJv2v7Vk=
 github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
 github.com/cloudflare/circl v1.6.4 h1:pOXuDTCEYyzydgUpQ0CQz3LsinKjiSk6nNP5Lt5K64U=


### PR DESCRIPTION
Linear: RED-722

Adds the optional `path` attribute to `checkly_client_certificate`, mirroring the new `path` property of the Checkly public API: a URL path prefix that limits a client certificate to API check requests under that path (whole path segments, so `/partner` applies to `/partner/orders` but not `/partnership`). The attribute is `ForceNew` like every other attribute of this resource. A `StateFunc` drops a trailing `/` the same way the API does, so `path = "/partner/api/"` does not plan a replacement on every apply.

Also corrects the resource description, which said certificates are bound to a single domain name while the example (and the API) accept wildcard hosts.

**Merge order:** depends on checkly/checkly-go-sdk v1.23.0 (adds `ClientCertificate.Path`), which `go.mod` now pins. The Checkly API must accept `path` before the provider release is announced.

- `checkly/resource_client_certificate.go`: schema attribute, create/read plumbing, description.
- `checkly/resource_client_certificate_test.go`: acceptance config uses `/partner/api/` and expects the normalized `/partner/api` in state.
- `examples/resources/checkly_client_certificate/resource.tf` and regenerated `docs/resources/client_certificate.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

