### PR TITLE
feat(playwright): detect Node version from Volta's package.json pin [RED-933]

### DIFF
--- a/checkly/engine.go
+++ b/checkly/engine.go
@@ -82,6 +82,26 @@ func parsePackageJSONEngines(content []byte) (nodeRange string, bunRange string)
 	return pkg.Engines.Node, pkg.Engines.Bun
 }
 
+// parsePackageJSONVoltaNode returns the Node version pinned by Volta in
+// package.json ("volta": {"node": "24.17.0"}), or "" when absent. Volta can
+// also pin package managers (volta.npm, volta.yarn, volta.pnpm) but never
+// Bun, so volta.node is the only key relevant to engine detection. A "volta.extends"
+// reference to another manifest is not followed: the code bundle archive
+// holds just the check's own directory, and an extends target normally
+// points at a workspace-root manifest that is not part of the archive.
+func parsePackageJSONVoltaNode(content []byte) string {
+	var pkg struct {
+		Volta struct {
+			Node string `json:"node"`
+		} `json:"volta"`
+	}
+	if err := json.Unmarshal(content, &pkg); err != nil {
+		return ""
+	}
+	s := strings.TrimSpace(pkg.Volta.Node)
+	return strings.TrimPrefix(s, "v")
+}
+
 func resolveNodeMajorVersion(raw string) string {
 	if raw == "" {
 		return ""
@@ -262,8 +282,22 @@ func detectEngine(files map[string][]byte, packageManager string) *EngineDetecti
 		}
 	}
 
-	// 5. package.json engines (range file — only consulted when no pinning file was found for that engine)
 	if raw, ok := files["package.json"]; ok {
+		// 5. package.json volta.node (pin — outranks the engines range, but
+		// loses to any dedicated version file). Like the other pinning
+		// sources, a value that cannot be resolved still claims the node
+		// candidate so the failure is reported rather than silently falling
+		// through to engines.node. This is stricter than .nvmrc, where aliases
+		// such as "lts/*" are skipped: Volta itself only ever writes exact
+		// versions, so an alias here is a broken pin worth surfacing.
+		if nodeCandidate == nil {
+			if pin := parsePackageJSONVoltaNode(raw); pin != "" {
+				resolved, notices := resolveConstraintForEngine("node", pin)
+				nodeCandidate = &candidate{engine: "node", version: resolved, rawVersion: pin, source: "package.json volta.node", notices: notices}
+			}
+		}
+
+		// 6. package.json engines (range file — only consulted when no pinning source was found for that engine)
 		nodeRange, bunRange := parsePackageJSONEngines(raw)
 		if nodeCandidate == nil && nodeRange != "" {
 			if resolved, notices := resolveConstraintForEngine("node", nodeRange); resolved != "" {

--- a/checkly/engine_test.go
+++ b/checkly/engine_test.go
@@ -54,10 +54,10 @@ func TestParseNvmrcFile(t *testing.T) {
 
 func TestParseToolVersionsFile(t *testing.T) {
 	tests := []struct {
-		name       string
-		content    string
-		wantNode   string
-		wantBun    string
+		name     string
+		content  string
+		wantNode string
+		wantBun  string
 	}{
 		{"nodejs entry", "nodejs 22.14.0", "22.14.0", ""},
 		{"bun entry", "bun 1.3.11", "", "1.3.11"},
@@ -121,6 +121,30 @@ func TestParsePackageJSONEngines(t *testing.T) {
 			if gotNode != tt.wantNode || gotBun != tt.wantBun {
 				t.Errorf("parsePackageJSONEngines(%q) = (%q, %q), want (%q, %q)",
 					tt.content, gotNode, gotBun, tt.wantNode, tt.wantBun)
+			}
+		})
+	}
+}
+
+func TestParsePackageJSONVoltaNode(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{"pin present", `{"volta":{"node":"24.17.0"}}`, "24.17.0"},
+		{"v prefix stripped", `{"volta":{"node":"v24.17.0"}}`, "24.17.0"},
+		{"whitespace trimmed", `{"volta":{"node":" 24.17.0 "}}`, "24.17.0"},
+		{"range value kept", `{"volta":{"node":"^22"}}`, "^22"},
+		{"pnpm pin ignored", `{"volta":{"pnpm":"10.30.0"}}`, ""},
+		{"no volta key", `{"engines":{"node":">=22"}}`, ""},
+		{"non-string node value", `{"volta":{"node":24}}`, ""},
+		{"malformed json", `{"volta":`, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := parsePackageJSONVoltaNode([]byte(tt.content)); got != tt.want {
+				t.Errorf("parsePackageJSONVoltaNode(%q) = %q, want %q", tt.content, got, tt.want)
 			}
 		})
 	}
@@ -221,6 +245,8 @@ func TestDetectEngine(t *testing.T) {
 		wantNil        bool
 		wantName       string
 		wantVersion    string
+		wantRawVersion string
+		wantSource     string
 	}{
 		{
 			name:           "node-version file",
@@ -356,6 +382,70 @@ func TestDetectEngine(t *testing.T) {
 			wantVersion:    "24",
 		},
 		{
+			name:           "volta pin selects node",
+			files:          map[string][]byte{"package.json": []byte(`{"volta":{"node":"24.17.0"}}`)},
+			packageManager: "npm",
+			wantName:       "node",
+			wantVersion:    "24",
+			wantRawVersion: "24.17.0",
+			wantSource:     "package.json volta.node",
+		},
+		{
+			name:           "volta range resolves through constraint",
+			files:          map[string][]byte{"package.json": []byte(`{"volta":{"node":"^22"}}`)},
+			packageManager: "npm",
+			wantName:       "node",
+			wantVersion:    "22",
+			wantSource:     "package.json volta.node",
+		},
+		{
+			name: "nvmrc beats volta pin",
+			files: map[string][]byte{
+				".nvmrc":       []byte("22"),
+				"package.json": []byte(`{"volta":{"node":"24.17.0"}}`),
+			},
+			packageManager: "npm",
+			wantName:       "node",
+			wantVersion:    "22",
+			wantSource:     ".nvmrc",
+		},
+		{
+			name: "tool-versions beats volta pin",
+			files: map[string][]byte{
+				".tool-versions": []byte("nodejs 22.0.0"),
+				"package.json":   []byte(`{"volta":{"node":"24.17.0"}}`),
+			},
+			packageManager: "npm",
+			wantName:       "node",
+			wantVersion:    "22",
+			wantSource:     ".tool-versions",
+		},
+		{
+			name:           "volta pin beats engines.node range",
+			files:          map[string][]byte{"package.json": []byte(`{"volta":{"node":"24.17.0"},"engines":{"node":">=22"}}`)},
+			packageManager: "npm",
+			wantName:       "node",
+			wantVersion:    "24",
+			wantSource:     "package.json volta.node",
+		},
+		{
+			name:           "volta pin with bun package manager still yields node",
+			files:          map[string][]byte{"package.json": []byte(`{"volta":{"node":"24.17.0"}}`)},
+			packageManager: "bun",
+			wantName:       "node",
+			wantVersion:    "24",
+			wantSource:     "package.json volta.node",
+		},
+		{
+			name:           "unresolvable volta pin claims node with empty version",
+			files:          map[string][]byte{"package.json": []byte(`{"volta":{"node":"lts"},"engines":{"node":">=22"}}`)},
+			packageManager: "npm",
+			wantName:       "node",
+			wantVersion:    "",
+			wantRawVersion: "lts",
+			wantSource:     "package.json volta.node",
+		},
+		{
 			name:           "empty node-version file returns nil",
 			files:          map[string][]byte{".node-version": []byte("")},
 			packageManager: "npm",
@@ -392,6 +482,12 @@ func TestDetectEngine(t *testing.T) {
 			}
 			if got.Engine.Version != tt.wantVersion {
 				t.Errorf("detectEngine().Engine.Version = %q, want %q", got.Engine.Version, tt.wantVersion)
+			}
+			if tt.wantRawVersion != "" && got.RawVersion != tt.wantRawVersion {
+				t.Errorf("detectEngine().RawVersion = %q, want %q", got.RawVersion, tt.wantRawVersion)
+			}
+			if tt.wantSource != "" && got.Source != tt.wantSource {
+				t.Errorf("detectEngine().Source = %q, want %q", got.Source, tt.wantSource)
 			}
 		})
 	}

--- a/checkly/resource_playwright_check_suite.go
+++ b/checkly/resource_playwright_check_suite.go
@@ -236,11 +236,18 @@ func resourcePlaywrightCheckSuite() *schema.Resource {
 							},
 						},
 						"engine": {
-							Description: "The JavaScript engine used to run the Playwright tests.",
-							Type:        schema.TypeList,
-							Optional:    true,
-							Computed:    true,
-							MaxItems:    1,
+							Description: "The JavaScript engine used to run the Playwright tests. " +
+								"When `auto_detect` is enabled, no engine is set, and the code bundle has a " +
+								"lockfile at its root, the engine is detected from files at the bundle root. " +
+								"Node is taken from the first of `.node-version`, `.nvmrc`, `.tool-versions`, " +
+								"the `volta.node` pin in `package.json`, then `engines.node` in `package.json`; " +
+								"Bun from the first of `.tool-versions`, `.bun-version`, then `engines.bun`. " +
+								"When both are found, the engine matching the lockfile's package manager wins. " +
+								"`volta.extends` is not followed.",
+							Type:     schema.TypeList,
+							Optional: true,
+							Computed: true,
+							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"name": {

--- a/checkly/resource_playwright_code_bundle.go
+++ b/checkly/resource_playwright_code_bundle.go
@@ -244,7 +244,7 @@ func resourcePlaywrightCodeBundleDelete(
 	return diags
 }
 
-const PlaywrightCodeBundleMetadataCurrentVersion = 6
+const PlaywrightCodeBundleMetadataCurrentVersion = 7
 
 type PlaywrightCodeBundleMetadata struct {
 	Version           int    `json:"v"`
@@ -574,7 +574,8 @@ func (a *PlaywrightCodeBundlePrebuiltArchiveAttribute) InspectLockfile(
 		return nil, fmt.Errorf("failed to compute archive checksum: %w", err)
 	}
 
-	// Add root package.json to engine files for engines field detection
+	// Add root package.json to engine files so the detector can read the
+	// Volta pin (volta.node) and the engines field.
 	for _, entry := range packageJSONs {
 		if entry.path == "package.json" {
 			engineFiles["package.json"] = entry.raw

--- a/checkly/resource_playwright_code_bundle_test.go
+++ b/checkly/resource_playwright_code_bundle_test.go
@@ -777,6 +777,28 @@ func TestInspectLockfileDetectsEngine(t *testing.T) {
 		}
 	})
 
+	t.Run("package.json volta.node pin beats engines.node", func(t *testing.T) {
+		t.Parallel()
+		archive := buildTarGz(t, []tarEntry{
+			{name: "package-lock.json", content: []byte(syntheticPackageLock)},
+			{name: "package.json", content: []byte(`{"name":"test","dependencies":{"@playwright/test":"1.58.2"},"volta":{"node":"24.17.0"},"engines":{"node":">=22"}}`)},
+		})
+		attr := PlaywrightCodeBundlePrebuiltArchiveAttribute{File: archive}
+		info, err := attr.InspectLockfile("@playwright/test", InspectLockfileOptions{})
+		if err != nil {
+			t.Fatalf("InspectLockfile failed: %v", err)
+		}
+		if info.Engine != "node" {
+			t.Errorf("Engine = %q, want %q", info.Engine, "node")
+		}
+		if info.EngineVersion != "24" {
+			t.Errorf("EngineVersion = %q, want %q", info.EngineVersion, "24")
+		}
+		if info.EngineSource != "package.json volta.node" {
+			t.Errorf("EngineSource = %q, want %q", info.EngineSource, "package.json volta.node")
+		}
+	})
+
 	t.Run("package.json engines.node", func(t *testing.T) {
 		t.Parallel()
 		archive := buildTarGz(t, []tarEntry{

--- a/docs/resources/playwright_check_suite.md
+++ b/docs/resources/playwright_check_suite.md
@@ -230,7 +230,7 @@ Optional:
 Optional:
 
 - `auto_detect` (Boolean) Whether to automatically detect appropriate runtime environment configuration from the bundle. (Default `true`).
-- `engine` (Block List, Max: 1) The JavaScript engine used to run the Playwright tests. (see [below for nested schema](#nestedblock--runtime--engine))
+- `engine` (Block List, Max: 1) The JavaScript engine used to run the Playwright tests. When `auto_detect` is enabled, no engine is set, and the code bundle has a lockfile at its root, the engine is detected from files at the bundle root. Node is taken from the first of `.node-version`, `.nvmrc`, `.tool-versions`, the `volta.node` pin in `package.json`, then `engines.node` in `package.json`; Bun from the first of `.tool-versions`, `.bun-version`, then `engines.bun`. When both are found, the engine matching the lockfile's package manager wins. `volta.extends` is not followed. (see [below for nested schema](#nestedblock--runtime--engine))
 - `playwright` (Block List, Max: 1) Configure the Playwright capabilities that should be made available to the runtime environment. (see [below for nested schema](#nestedblock--runtime--playwright))
 - `steps` (Block List, Max: 1) Customize the actions taken during test execution. (see [below for nested schema](#nestedblock--runtime--steps))
 - `working_dir` (String) The working directory in which runtime commands are executed. This is useful for monorepos or workspaces where the Playwright project is in a subdirectory. Use "." to explicitly specify the root.


### PR DESCRIPTION
Linear: RED-933

## Summary

`checkly_playwright_code_bundle` now detects the Node engine from Volta's pin in the root `package.json` (`"volta": { "node": "24.17.0" }`). Projects standardised on Volta usually have no `.nvmrc` or `.node-version`, so until now they fell through to `engines.node` or the default engine.

- **Precedence**: `.node-version` → `.nvmrc` → `.tool-versions` → `.bun-version` → `package.json` `volta.node` → `package.json` `engines`. An explicit pin outranks a semver range; dedicated version files still win. This matches the order proposed for the CLI in RED-932.
- **Values** are resolved through the existing `resolveConstraintForEngine`, so both exact pins (`24.17.0` → 24) and ranges (`^22` → 22) work.
- **Unresolvable values** (e.g. a hand-edited `"node": "lts"`) still claim the node candidate, so the check suite reports its existing "denied or could not be resolved" error instead of silently falling through to `engines`. Volta itself only writes exact versions, so this is intentionally stricter than `.nvmrc` alias handling.
- **`volta.extends` is not followed**: the archive only contains the check's directory, and only the root manifest reaches the detector.
- **Docs**: the `runtime.engine` description on `checkly_playwright_check_suite` now describes the detection order, the root-lockfile prerequisite, and the package-manager tiebreak between Node and Bun candidates.

## Behaviour change for existing state

`PlaywrightCodeBundleMetadataCurrentVersion` is bumped from 6 to 7, so every existing `checkly_playwright_code_bundle` re-runs detection once on the next plan. For Volta projects this may change the auto-detected `runtime.engine`; that is the intended effect.

## Tests

- `TestParsePackageJSONVoltaNode`: pin, `v` prefix, whitespace, range, missing/invalid values.
- `TestDetectEngine`: pin, range, pin vs `.nvmrc`, pin vs `.tool-versions`, pin vs `engines.node`, bun package manager, unresolvable pin (now also asserts source and raw version).
- `TestInspectLockfileDetectsEngine`: archive-level case proving the pin is read through the tar walker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
