### PR TITLE
fix: support multi-document pnpm lockfiles

### DIFF
--- a/checkly/lockfile.go
+++ b/checkly/lockfile.go
@@ -48,38 +48,47 @@ func extractPackageVersionFromPackageLock(r io.Reader, packageName string) (stri
 
 // extractPackageVersionFromPnpmLock extracts the version of the given package
 // from a pnpm-lock.yaml file. Checks both the packages section (all versions)
-// and the importers section (workspace-specific dependencies).
+// and the importers section (workspace-specific dependencies). Reads successive
+// YAML documents because pnpm 12 can prepend an environment lockfile document.
 func extractPackageVersionFromPnpmLock(r io.Reader, packageName string) (string, error) {
-	var lockfile struct {
-		Packages  map[string]any `yaml:"packages"`
-		Importers map[string]struct {
-			Dependencies    map[string]pnpmImporterDep `yaml:"dependencies"`
-			DevDependencies map[string]pnpmImporterDep `yaml:"devDependencies"`
-		} `yaml:"importers"`
-	}
+	decoder := yaml.NewDecoder(r)
+	decodedAny := false
 
-	if err := yaml.NewDecoder(r).Decode(&lockfile); err != nil {
-		return "", fmt.Errorf("failed to parse pnpm-lock.yaml: %w", err)
-	}
+	for {
+		var lockfile struct {
+			Packages  map[string]any `yaml:"packages"`
+			Importers map[string]struct {
+				Dependencies    map[string]pnpmImporterDep `yaml:"dependencies"`
+				DevDependencies map[string]pnpmImporterDep `yaml:"devDependencies"`
+			} `yaml:"importers"`
+		}
 
-	// Check packages section first — version is encoded in the key.
-	for key := range lockfile.Packages {
-		if version := extractVersionFromPnpmPackageKey(key, packageName); version != "" {
-			return version, nil
+		err := decoder.Decode(&lockfile)
+		if err == io.EOF && decodedAny {
+			return "", nil
+		}
+		if err != nil {
+			return "", fmt.Errorf("failed to parse pnpm-lock.yaml: %w", err)
+		}
+		decodedAny = true
+
+		// Check packages section first — version is encoded in the key.
+		for key := range lockfile.Packages {
+			if version := extractVersionFromPnpmPackageKey(key, packageName); version != "" {
+				return version, nil
+			}
+		}
+
+		// Fallback: check importers (workspace packages) for the dependency.
+		for _, importer := range lockfile.Importers {
+			if dep, ok := importer.Dependencies[packageName]; ok && dep.Version != "" {
+				return dep.Version, nil
+			}
+			if dep, ok := importer.DevDependencies[packageName]; ok && dep.Version != "" {
+				return dep.Version, nil
+			}
 		}
 	}
-
-	// Fallback: check importers (workspace packages) for the dependency.
-	for _, importer := range lockfile.Importers {
-		if dep, ok := importer.Dependencies[packageName]; ok && dep.Version != "" {
-			return dep.Version, nil
-		}
-		if dep, ok := importer.DevDependencies[packageName]; ok && dep.Version != "" {
-			return dep.Version, nil
-		}
-	}
-
-	return "", nil
 }
 
 type pnpmImporterDep struct {

--- a/checkly/lockfile_test.go
+++ b/checkly/lockfile_test.go
@@ -174,6 +174,128 @@ packages: {}
 			want: "1.48.0",
 		},
 		{
+			name:        "pnpm 12 multi-document lockfile",
+			packageName: "@playwright/test",
+			input: `---
+lockfileVersion: '9.0'
+importers:
+  .:
+    configDependencies: {}
+    packageManagerDependencies:
+      pnpm:
+        specifier: 12.3.4
+        version: 12.3.4
+packages:
+  pnpm@12.3.4: {}
+---
+lockfileVersion: '9.0'
+packages:
+  '@playwright/test@1.62.1':
+    resolution: {integrity: sha512-xxx}
+`,
+			want: "1.62.1",
+		},
+		{
+			name:        "importers fallback in later document",
+			packageName: "@playwright/test",
+			input: `lockfileVersion: '9.0'
+settings:
+  autoInstallPeers: true
+---
+lockfileVersion: '9.0'
+importers:
+  .:
+    devDependencies:
+      '@playwright/test':
+        specifier: ^1.62.1
+        version: 1.62.1
+`,
+			want: "1.62.1",
+		},
+		{
+			name:        "empty documents are skipped",
+			packageName: "@playwright/test",
+			input: `---
+---
+lockfileVersion: '9.0'
+packages:
+  '@playwright/test@1.62.1': {}
+`,
+			want: "1.62.1",
+		},
+		{
+			name:        "package not found across documents",
+			packageName: "@playwright/test",
+			input: `lockfileVersion: '9.0'
+packages:
+  typescript@5.9.2: {}
+---
+lockfileVersion: '9.0'
+importers:
+  .:
+    devDependencies:
+      typescript:
+        specifier: ^5.9.2
+        version: 5.9.2
+`,
+			want: "",
+		},
+		{
+			name:        "malformed later document",
+			packageName: "@playwright/test",
+			input: `lockfileVersion: '9.0'
+packages: {}
+---
+{not yaml
+`,
+			wantErr: true,
+		},
+		{
+			name:        "first match returns before malformed later document",
+			packageName: "@playwright/test",
+			input: `lockfileVersion: '9.0'
+packages:
+  '@playwright/test@1.62.1': {}
+---
+{not yaml
+`,
+			want: "1.62.1",
+		},
+		{
+			name:        "first matching document wins",
+			packageName: "@playwright/test",
+			input: `lockfileVersion: '9.0'
+packages:
+  '@playwright/test@1.61.0': {}
+---
+lockfileVersion: '9.0'
+packages:
+  '@playwright/test@1.62.1': {}
+`,
+			want: "1.61.0",
+		},
+		{
+			name:        "packages take precedence over importers",
+			packageName: "@playwright/test",
+			input: `lockfileVersion: '9.0'
+packages:
+  '@playwright/test@1.62.1': {}
+importers:
+  .:
+    devDependencies:
+      '@playwright/test':
+        specifier: ^1.60.0
+        version: 1.60.0
+`,
+			want: "1.62.1",
+		},
+		{
+			name:        "empty input remains an error",
+			packageName: "@playwright/test",
+			input:       "",
+			wantErr:     true,
+		},
+		{
 			name:        "different package",
 			packageName: "typescript",
 			input: `lockfileVersion: '9.0'

--- a/checkly/resource_playwright_code_bundle_test.go
+++ b/checkly/resource_playwright_code_bundle_test.go
@@ -218,6 +218,52 @@ func TestInspectLockfile(t *testing.T) {
 		})
 	}
 
+	t.Run("pnpm with environment and dependency documents", func(t *testing.T) {
+		t.Parallel()
+
+		archive := buildTarGz(t, []tarEntry{
+			{name: "pnpm-lock.yaml", content: []byte(`---
+lockfileVersion: '9.0'
+importers:
+  .:
+    packageManagerDependencies:
+      pnpm:
+        specifier: 12.3.4
+        version: 12.3.4
+packages:
+  pnpm@12.3.4: {}
+---
+lockfileVersion: '9.0'
+importers:
+  .:
+    devDependencies:
+      '@playwright/test':
+        specifier: ^1.58.2
+        version: 1.58.2
+packages:
+  '@playwright/test@1.58.2': {}
+`)},
+		})
+		attr := PlaywrightCodeBundlePrebuiltArchiveAttribute{File: archive}
+
+		info, err := attr.InspectLockfile("@playwright/test", InspectLockfileOptions{})
+		if err != nil {
+			t.Fatalf("InspectLockfile failed: %v", err)
+		}
+		if info == nil {
+			t.Fatal("InspectLockfile returned nil")
+		}
+		if info.PackageManager != "pnpm" {
+			t.Errorf("PackageManager = %q, want %q", info.PackageManager, "pnpm")
+		}
+		if info.PackageVersion != "1.58.2" {
+			t.Errorf("PackageVersion = %q, want %q", info.PackageVersion, "1.58.2")
+		}
+		if info.ChecksumSha256 == "" {
+			t.Error("ChecksumSha256 is empty")
+		}
+	})
+
 	t.Run("lockfile without @playwright/test", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
**Bug**: pnpm 12 writes `pnpm-lock.yaml` as two YAML documents when `packageManager` pins pnpm. The parser decoded only the first (env) document, so `checkly_playwright_code_bundle` failed with "the lockfile does not contain @playwright/test" on valid lockfiles.

**Fix**: decode successive documents until a match or end of stream. Single-document lockfiles take the identical path as before.

**Credit**: this is @bengry's fix from #393, cherry-picked verbatim with a signed commit so it can merge.

**Verified**: `terraform plan` against a real pnpm 12.3.4 two-document archive fails on `main` with the exact reported error and plans cleanly on this branch with Playwright 1.55.0 detected.

## Affected Components
* [x] Resources
* [x] Test

> Resolves #392